### PR TITLE
chore: use servor to test the production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "scripts": {
     "build": "run-s format type:check build:vite build:postoptimize",
-    "start": "lws --port=4321 --dir=dist/",
+    "start": "servor ./dist/ --browse",
     "dev": "vite",
     "build:vite": "vite build",
     "build:postoptimize": "node ./postoptimize.mjs",
@@ -45,6 +45,7 @@
     "patch-package": "^6.4.7",
     "postcss": "^8.3.5",
     "prettier": "^2.3.2",
+    "servor": "^4.0.2",
     "shiki": "^0.9.5",
     "svgo": "^2.3.1",
     "tailwindcss": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "scripts": {
     "build": "run-s format type:check build:vite build:postoptimize",
-    "start": "vite",
+    "start": "lws --port=4321 --dir=dist/",
     "dev": "vite",
     "build:vite": "vite build",
     "build:postoptimize": "node ./postoptimize.mjs",
@@ -38,6 +38,7 @@
     "globby": "^11.0.4",
     "got": "^11.8.2",
     "jiti": "^1.10.1",
+    "light-web-server": "^1.3.0",
     "markdown-it": "^12.0.6",
     "markdown-it-anchor": "^8.0.4",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Vite command builds the package using dev configuration by default, which is not the same as the production code. To test the actual website in production without any changes, a pure server like ~lws~ servor should be used.