### PR TITLE
Revert "chore: use servor instead of lws"

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "scripts": {
     "build": "run-s format type:check build:vite build:postoptimize",
-    "start": "servor ./dist/ --browse",
+    "start": "lws --port=4321 --dir=dist/",
     "dev": "vite",
     "build:vite": "vite build",
     "build:postoptimize": "node ./postoptimize.mjs",
@@ -47,7 +47,6 @@
     "patch-package": "^6.4.7",
     "postcss": "^8.3.5",
     "prettier": "^2.3.2",
-    "servor": "^4.0.2",
     "shiki": "^0.9.5",
     "svgo": "^2.3.1",
     "tailwindcss": "^2.2.4",


### PR DESCRIPTION
This reverts commit afef109dbcd931fbe01e7ba99bc95984dbf1bae6 from #75

I had some trust in lws, and that's why I was suggesting it. 😄  

Servor fails to serve the page changes. For example, the docs button in navbar doesn't work with servor