### PR TITLE
perf: run htmlnano on the markdown files

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "front-matter": "^4.0.2",
     "globby": "^11.0.4",
     "got": "^11.8.2",
+    "htmlnano": "^1.0.0",
     "jiti": "^1.10.1",
     "light-web-server": "^1.3.0",
     "markdown-it": "^12.0.6",

--- a/scripts/fetchReleases.ts
+++ b/scripts/fetchReleases.ts
@@ -7,6 +7,8 @@ import frontmatter from 'front-matter';
 import anchor, { AnchorInfo } from 'markdown-it-anchor';
 import Token from 'markdown-it/lib/token';
 import { getHighlighter, loadTheme } from 'shiki';
+// @ts-ignore
+import htmlnano from 'htmlnano';
 import { existsSync } from 'fs';
 import { writeFile, mkdir, readFile } from 'fs/promises';
 import { resolve, dirname } from 'path';
@@ -68,7 +70,10 @@ async function processMarkdown(mdToProcess: string) {
     },
   });
 
-  const html = '<section class="mt-10">' + md.render(body) + '</section>';
+  const renderedMarkdown = md.render(body)
+  const optimizedMarkdown = (await htmlnano.process(renderedMarkdown)).html
+
+  const html = '<section class="mt-10">' + optimizedMarkdown + '</section>';
 
   return { html, attributes, sections };
 }


### PR DESCRIPTION
This reduces the size of the JSON files that are used to render the markdown files. Since running the `fetch releases` script requires authentication, I could not run it on all the files.

However, I did a test with the `content` property of  `1.0.0.json`. It reduced the length of the HTML string by `6,117` characters.

The length of the HTML string:

After:
`330,646`

Before:
`336,763`



