### PR TITLE
fix: swap fonts once they are downloaded

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -7,7 +7,7 @@
     url('./fonts/Gordita/Gordita Regular.ttf') format('truetype');
   font-weight: 500;
   font-style: normal;
-  font-display: fallback;
+  font-display: swap;
 }
 @font-face {
   font-family: 'Gordita';
@@ -16,7 +16,7 @@
     url('./fonts/Gordita/Gordita Thin.ttf') format('truetype');
   font-weight: 100;
   font-style: normal;
-  font-display: fallback;
+  font-display: swap;
 }
 @font-face {
   font-family: 'Gordita';
@@ -25,7 +25,7 @@
     url('./fonts/Gordita/Gordita Medium.ttf') format('truetype');
   font-weight: 600;
   font-style: normal;
-  font-display: fallback;
+  font-display: swap;
 }
 @font-face {
   font-family: 'Gordita';
@@ -34,7 +34,7 @@
     url('./fonts/Gordita/Gordita Bold.ttf') format('truetype');
   font-weight: 700;
   font-style: normal;
-  font-display: fallback;
+  font-display: swap;
 }
 
 @tailwind base;


### PR DESCRIPTION
Reduces the first time to visibility by 230ms

Using swap means that the text will be still visible during downloading of the font. But fallback hides the text during downloading

Fixes
https://web.dev/font-display/?utm_source=lighthouse&utm_medium=devtools

![image](https://user-images.githubusercontent.com/16418197/124340408-aa06d680-db7a-11eb-8fae-5d8c8aaba921.png)
