### PR TITLE
Fix bug on multi-tab tutorial when switching between solved/reset

### DIFF
--- a/src/pages/Tutorial.tsx
+++ b/src/pages/Tutorial.tsx
@@ -181,6 +181,7 @@ const Tutorial: Component<TutorialProps> = (props) => {
     if (!url) return;
     const data = await fetch(url).then((r) => r.json());
     batch(() => {
+      setCurrent('main.tsx');
       const newTabs = data.files.map((file: { name: string; type?: string; content: string }) => {
         return {
           name: file.name,
@@ -189,7 +190,6 @@ const Tutorial: Component<TutorialProps> = (props) => {
         };
       });
       setTabs(newTabs);
-      setCurrent('main.tsx');
     });
   });
   return (


### PR DESCRIPTION
This PR fixes the issue #76.

Somehow, the order of the setters function calls in `batch` seems to matter in this case.

By moving `setCurrent` before the `setTabs`, the issue seems to not be present afterwards.

I don't really understand the origin of this issue, though, my knowledge on Solid.js is really limited.

Hope it helps at least pin point the issue