### PR TITLE
update DirectoryMenu to scroll to the active section instead of active section title

### DIFF
--- a/src/pages/Tutorial.tsx
+++ b/src/pages/Tutorial.tsx
@@ -82,7 +82,7 @@ const DirectoryMenu: Component<DirectoryProps> = (props) => {
       search.focus();
 
       // Find the closest section and scroll it into the view
-      listContainer.querySelector('.js-active')?.closest('.js-section-title')?.scrollIntoView();
+      listContainer.querySelector('.js-active')?.scrollIntoView();
     } else {
       window.removeEventListener('click', listener);
       window.removeEventListener('keydown', listener);


### PR DESCRIPTION
This should fix #81 

It seems like there is no perfect solution without trade-off here.

Either we change the `scrollIntoView` target to the active section, and we are sure the active section will always be visible when opening the menu (what this PR is doing), but we lose the title visibility on a smaller screen, or we keep the title always visible (current behavior), but some smaller screen will not see the active section.

I guess it's also possible to bake some solution with both, but it might be a little too much code just for this.

Feel free to close this PR if the solution is not what you wanted.

Cheers !