### PR TITLE
Scroll shadows and sticky logo

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -95,24 +95,45 @@
 
 .fadeout-after-navbar:after {
   content: '';
-  width: 100%;
+  width: 30%;
   height: 100%;
   position: absolute;
-  left: 0;
+  right: 0;
   top: 0;
   pointer-events: none;
-  background: linear-gradient(to left, white, 6%, transparent);
+  background: linear-gradient(to left, rgba(255, 255, 255, 1), 50%, rgba(255, 255, 255, 0));
 }
 
 .fadeout-before-navbar:before {
   content: '';
-  width: 100%;
+  width: 30%;
   height: 100%;
   position: absolute;
   left: 0;
   top: 0;
   pointer-events: none;
-  background: linear-gradient(to right, white, 6%, transparent);
+  background: linear-gradient(to right, rgba(255, 255, 255, 1), 50%, rgba(255, 255, 255, 0));
+}
+
+.nav-items-container {
+  flex-shrink: 0;
+  flex-grow: 1;
+  flex-basis: 0px;
+  min-width: 0px;
+}
+
+.nav-logo-bg {
+  background: linear-gradient(to right, rgba(255, 255, 255, 1), 92%, rgba(255, 255, 255, 0));
+}
+
+/* Chrome, Safari and Opera */
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+.no-scrollbar {
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
 }
 
 /* START TOOLTIP STYLES */

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -92,45 +92,19 @@
 .chevron.chevron-right:hover::after {
   left: 0.45em;
 }
-
-.fadeout-after-navbar:after {
-  content: '';
-  width: 30%;
-  height: 100%;
-  position: absolute;
-  right: 0;
-  top: 0;
-  pointer-events: none;
-  background: linear-gradient(to left, rgba(255, 255, 255, 1), 50%, rgba(255, 255, 255, 0));
-}
-
-.fadeout-before-navbar:before {
-  content: '';
-  width: 30%;
-  height: 100%;
-  position: absolute;
-  left: 0;
-  top: 0;
-  pointer-events: none;
-  background: linear-gradient(to right, rgba(255, 255, 255, 1), 50%, rgba(255, 255, 255, 0));
-}
-
 .nav-items-container {
   flex-shrink: 0;
   flex-grow: 1;
   flex-basis: 0px;
   min-width: 0px;
 }
-
 .nav-logo-bg {
   background: linear-gradient(to right, rgba(255, 255, 255, 1), 92%, rgba(255, 255, 255, 0));
 }
-
 /* Chrome, Safari and Opera */
 .no-scrollbar::-webkit-scrollbar {
   display: none;
 }
-
 .no-scrollbar {
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -16,7 +16,7 @@ const links: MenuLinkProps[] = [
 ];
 
 const Logo: Component<{ show: boolean }> = (props) => (
-  <li class="pr-5 sticky z-10 left-0 nav-logo-bg">
+  <li class="sticky z-10 left-0 nav-logo-bg" classList={{ 'pr-5': props.show }}>
     <Link href="/" class={`py-3 flex transition-all ${props.show ? 'w-9' : 'w-0'}`}>
       <span class="sr-only">Navigate to the home page</span>
       <img class="w-full h-auto" src={logo} alt="Solid logo" />
@@ -74,7 +74,8 @@ const Nav: Component<{ showLogo?: boolean; filled?: boolean }> = (props) => {
           <ScrollShadow
             class="relative nav-items-container"
             direction="horizontal"
-            shadowSize="25%"
+            shadowSize={'25%'}
+            initShadowSize={true}
           >
             <ul ref={scrollRef} class="relative flex items-center overflow-auto no-scrollbar">
               <Logo show={shouldShowLogo()} />

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -74,7 +74,7 @@ const Nav: Component<{ showLogo?: boolean; filled?: boolean }> = (props) => {
           <ScrollShadow
             class="relative nav-items-container"
             direction="horizontal"
-            shadowSize={'25%'}
+            shadowSize="25%"
             initShadowSize={true}
           >
             <ul ref={scrollRef} class="relative flex items-center overflow-auto no-scrollbar">

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -2,6 +2,7 @@ import { Link, NavLink } from 'solid-app-router';
 import { Component, For, onCleanup, onMount, createSignal, Show } from 'solid-js';
 
 import logo from '../assets/logo.svg';
+import ScrollShadow from './ScrollShadow/ScrollShadow';
 import Social from './Social';
 
 const links: MenuLinkProps[] = [
@@ -15,7 +16,7 @@ const links: MenuLinkProps[] = [
 ];
 
 const Logo: Component<{ show: boolean }> = (props) => (
-  <li class="mr-4">
+  <li class="pr-5 sticky z-10 left-0 nav-logo-bg">
     <Link href="/" class={`py-3 flex transition-all ${props.show ? 'w-9' : 'w-0'}`}>
       <span class="sr-only">Navigate to the home page</span>
       <img class="w-full h-auto" src={logo} alt="Solid logo" />
@@ -48,8 +49,7 @@ const MenuLink: Component<MenuLinkProps> = (props) => (
 );
 
 const Nav: Component<{ showLogo?: boolean; filled?: boolean }> = (props) => {
-  const [unlocked, setUnlocked] = createSignal(props.showLogo);
-  const [classList, setClassList] = createSignal({});
+  const [unlocked, setUnlocked] = createSignal(true);
   let intersectorRef!: HTMLDivElement;
   let scrollRef!: HTMLUListElement;
 
@@ -57,27 +57,9 @@ const Nav: Component<{ showLogo?: boolean; filled?: boolean }> = (props) => {
     const observer = new IntersectionObserver(([entry]) => setUnlocked(entry.isIntersecting));
     observer.observe(intersectorRef);
     onCleanup(() => observer && observer.disconnect());
-    handleScrollMobile(scrollRef);
   });
 
   const shouldShowLogo = () => props.showLogo || !unlocked();
-
-  const handleScrollMobile = (element: HTMLElement) => {
-    const scrollLeft = element.scrollLeft;
-    const scrollRight = scrollLeft - element.scrollWidth + element.offsetWidth;
-    const newClassList: { [cls: string]: boolean } = {};
-    if (scrollLeft > 10) {
-      newClassList['fadeout-before-navbar'] = true;
-    } else {
-      newClassList['fadeout-before-navbar'] = false;
-    }
-    if (scrollRight < -10) {
-      newClassList['fadeout-after-navbar'] = true;
-    } else {
-      newClassList['fadeout-after-navbar'] = false;
-    }
-    setClassList(newClassList);
-  };
 
   return (
     <>
@@ -89,15 +71,17 @@ const Nav: Component<{ showLogo?: boolean; filled?: boolean }> = (props) => {
         }}
       >
         <nav class="px-3 lg:px-12 container lg:flex justify-between items-center max-h-18 relative z-20 space-x-10">
-          <ul
-            ref={scrollRef}
-            classList={classList()}
-            onScroll={(e) => handleScrollMobile(e.currentTarget)}
-            class="flex items-center overflow-auto"
+          <ScrollShadow
+            class="relative nav-items-container"
+            direction="horizontal"
+            shadowSize="25%"
           >
-            <Logo show={shouldShowLogo()} />
-            <For each={links} children={MenuLink} />
-          </ul>
+            <ul ref={scrollRef} class="relative flex items-center overflow-auto no-scrollbar">
+              <Logo show={shouldShowLogo()} />
+              <For each={links} children={MenuLink} />
+            </ul>
+          </ScrollShadow>
+
           <ul class="lg:flex hidden items-center space-x-3">
             <Social />
           </ul>

--- a/src/components/ScrollShadow/ScrollShadow.tsx
+++ b/src/components/ScrollShadow/ScrollShadow.tsx
@@ -1,0 +1,103 @@
+import { Component, onCleanup, onMount } from 'solid-js';
+
+type TShared = {
+  direction: 'horizontal' | 'vertical';
+  child: 'first' | 'last';
+  size: string;
+};
+
+/**
+ *
+ * child scrollable container should have already have overflow property and should have `position: relative;` in order to make Intersection Observer to work.
+ */
+const ScrollShadow: Component<
+  {
+    class: string;
+    shadowSize: string;
+  } & Omit<TShared, 'child' | 'size'>
+> = (props) => {
+  const { class: className, direction, shadowSize } = props;
+  const sentinelShadowState = new Map<HTMLElement, HTMLElement>();
+  let shadowFirstEl!: HTMLElement;
+  let shadowLastEl!: HTMLElement;
+  let sentinelFirstEl = (<Sentinel child="first" direction={direction} />) as HTMLElement;
+  let sentinelLastEl = (<Sentinel child="last" direction={direction} />) as HTMLElement;
+
+  // won't work for SSR
+  const children = props.children as HTMLElement;
+  children.appendChild(sentinelFirstEl);
+  children.appendChild(sentinelLastEl);
+
+  onMount(() => {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        const target = entry.target as HTMLElement;
+        const shadowEl = sentinelShadowState.get(target);
+
+        let isVisible = false;
+
+        if (entry.isIntersecting) {
+          isVisible = true;
+        }
+        shadowEl!.style.opacity = isVisible ? '0' : '1';
+
+        console.log(target, isVisible);
+      });
+    });
+
+    sentinelShadowState.set(sentinelFirstEl, shadowFirstEl);
+    sentinelShadowState.set(sentinelLastEl, shadowLastEl);
+
+    observer.observe(sentinelFirstEl);
+    observer.observe(sentinelLastEl);
+
+    onCleanup(() => observer && observer.disconnect());
+  });
+
+  return (
+    <div class={className}>
+      <Shadow child="first" direction={direction} size={shadowSize} ref={shadowFirstEl} />
+      <Shadow child="last" direction={direction} size={shadowSize} ref={shadowLastEl} />
+
+      {children}
+    </div>
+  );
+};
+
+const Sentinel: Component<Omit<TShared, 'size'>> = ({ direction, child }) => {
+  const setPosition = (direction: string) => {
+    const isFirst = child === 'first';
+    if (direction === 'horizontal') {
+      return `position: ${isFirst ? 'absolute' : 'relative'}; top: 0; ${
+        isFirst ? 'left' : 'right'
+      }: 0; height: 100%; width: 1px`;
+    }
+    return `position: ${isFirst ? 'absolute' : 'relative'}; left: 0; ${
+      isFirst ? 'top' : 'bottom'
+    }: 0; height: 1px; width: 100%`;
+  };
+  const style = `pointer-events: none; ${setPosition(direction)}; `;
+  return <div style={style}></div>;
+};
+
+const Shadow: Component<{ ref: any } & TShared> = ({ ref, direction, child, size }) => {
+  const setPosition = (direction: string) => {
+    const isFirst = child === 'first';
+    if (direction === 'horizontal') {
+      return `top: 0; ${isFirst ? 'left' : 'right'}: 0;   background: linear-gradient(to ${
+        isFirst ? 'right' : 'left'
+      }, rgba(255, 255, 255, 1), 65%, rgba(255, 255, 255, 0)); width: ${size}; height: 100%`;
+    }
+
+    return `left: 0; ${isFirst ? 'top' : 'bottom'}: 0; background: linear-gradient(to ${
+      isFirst ? 'top' : 'bottom'
+    }, rgba(255, 255, 255, 1), 65%, rgba(255, 255, 255, 0)); width: ${size}; height: 28%`;
+  };
+  const style = `position: absolute; z-index: 1; pointer-events: none; opacity: 0; transition: 500ms opacity; ${setPosition(
+    direction,
+  )};`;
+
+  return <div ref={ref} style={style}></div>;
+};
+
+export default ScrollShadow;


### PR DESCRIPTION
## Scroll Shadows on Nav Scroll Container

Improvement on Scroll shadows, which indicates that container is scrollable/ more items to scroll.
![2021-08-04_01-55](https://user-images.githubusercontent.com/29286430/128135569-c9af610a-520f-40d1-a0cd-a2a0d5967640.png)

Scroll shadow size is "dynamic". An issue that will occur with static scroll shadow size is that in certain screen sizes,  the last visible item happens to be position outside the Scroll Shadow size. So the user can't tell that the container is scrollable. 

![Screenshot from 2021-08-04 00-41-55](https://user-images.githubusercontent.com/29286430/128133015-30d22114-d892-493e-9bec-5b965c64156e.png)

Increasing the Scroll Shadow size in order to solve it, will cause an issue that it will obscure too much in the Scrollable Container. The solution is setting a one time initial larger Scroll Shadow size, once interacted will return to its normal size.
![initgradientcomparision](https://user-images.githubusercontent.com/29286430/128132880-1aa3816b-e962-411f-8cd3-ec808a0f8eb1.png)

Here's an example where the shadow is scaled initially, then when interacted, revert to it's default size.
![Peek 2021-08-04 00-42](https://user-images.githubusercontent.com/29286430/128133184-930a9814-bff8-4073-bc9a-7f7a7f37b9cd.gif)


Default scrollbars are removed for minimalism, and Scroll Shadow is there as indication that the container is scrollable.

Fixed gray gradient bug in Safari, since in Webkit, to achieve transparent effect, the gradients "to from" colors has to have the same values but have different alpha values such as using rgba.

Shadows are no longer displayed based by scroll event, instead by Intersection Observer. Result is that it has slightly better runtime performance while scrolling.

I made the Scroll Shadow Container as a Component Wrapper. Its API is simple, just pass the scrollable element that contains the list as the child, and the Component adds the necessary elements such as shadows and sentinels(for Intersection Observer) behind the scenes. 
```js
<ScrollShadow
  class="relative nav-items-container"
  direction="horizontal"
  shadowSize="25%"
  initShadowSize={true}
>
  <ul ref={scrollRef} class="relative flex items-center overflow-auto no-scrollbar">
    <Logo show={shouldShowLogo()} />
    <For each={links} children={MenuLink} />
  </ul>
</ScrollShadow>
```
Since it adds some elements to the `props.children`, this won't work for SSR. For now I think it's okay since this site is client side generated. I will have to write the necessary code to deal with SSR in future.

## Sticky Logo
Logo is now sticky, this means that it is fixed even when Nav container is scrolled.
![Peek 2021-08-04 00-43](https://user-images.githubusercontent.com/29286430/128130459-4871b86c-9526-4361-a7ee-28ac1e758180.gif)
