### PR TITLE
Quick fix on Scroll shadow

### DIFF
--- a/src/components/ScrollShadow/ScrollShadow.tsx
+++ b/src/components/ScrollShadow/ScrollShadow.tsx
@@ -32,7 +32,6 @@ const ScrollShadow: Component<
   scrollableContainer.appendChild(sentinelLastEl);
 
   const scrollHorizontally = (e: WheelEvent) => {
-    e.preventDefault();
     const target = e.currentTarget as HTMLElement;
 
     target.scrollLeft += e.deltaY;

--- a/src/components/ScrollShadow/ScrollShadow.tsx
+++ b/src/components/ScrollShadow/ScrollShadow.tsx
@@ -27,9 +27,16 @@ const ScrollShadow: Component<
   let initResetSize = false;
 
   // won't work for SSR
-  const children = props.children as HTMLElement;
-  children.appendChild(sentinelFirstEl);
-  children.appendChild(sentinelLastEl);
+  const scrollableContainer = props.children as HTMLElement;
+  scrollableContainer.appendChild(sentinelFirstEl);
+  scrollableContainer.appendChild(sentinelLastEl);
+
+  const scrollHorizontally = (e: WheelEvent) => {
+    e.preventDefault();
+    const target = e.currentTarget as HTMLElement;
+
+    target.scrollLeft += e.deltaY;
+  };
 
   onMount(() => {
     const resetInitShadowSize = () => {
@@ -70,6 +77,8 @@ const ScrollShadow: Component<
       init = false;
     });
 
+    scrollableContainer.addEventListener('wheel', scrollHorizontally);
+
     sentinelShadowState.set(sentinelFirstEl, shadowFirstEl);
     sentinelShadowState.set(sentinelLastEl, shadowLastEl);
 
@@ -85,7 +94,7 @@ const ScrollShadow: Component<
       <Shadow child="first" direction={direction} shadowSize={shadowSize} ref={shadowFirstEl} />
       <Shadow child="last" direction={direction} shadowSize={shadowSize} ref={shadowLastEl} />
 
-      {children}
+      {scrollableContainer}
     </div>
   );
 };

--- a/src/components/ScrollShadow/ScrollShadow.tsx
+++ b/src/components/ScrollShadow/ScrollShadow.tsx
@@ -97,9 +97,9 @@ const Sentinel: Component<Omit<TShared, 'shadowSize' | 'initShadowSize'>> = ({
   const setPosition = (direction: string) => {
     const isFirst = child === 'first';
     if (direction === 'horizontal') {
-      return `position: ${isFirst ? 'absolute' : 'relative'}; top: 0; ${
+      return `position: ${isFirst ? 'absolute' : 'static'}; top: 0; ${
         isFirst ? 'left' : 'right'
-      }: 0; height: 100%; width: 1px`;
+      }: 0; height: 100%; width: 1px; ${isFirst ? '' : 'flex-shrink: 0; margin-left: -1px;'}`;
     }
     return `position: ${isFirst ? 'absolute' : 'relative'}; left: 0; ${
       isFirst ? 'top' : 'bottom'


### PR DESCRIPTION
During development, the Chrome dev mobile view was giving false positive that the last scroll shadow would hide once scrolling to the end. In actual Chrome android it doesn't work. This PR fixes that.