### PR TITLE
Remove automatic quotation marks from blockquote

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,6 +25,8 @@ module.exports = {
           css: {
             color: '#333',
             fontFamily: 'Gordita',
+            'blockquote p:first-of-type::before': { content: 'none' },
+            'blockquote p:first-of-type::after': { content: 'none' },
             h1: {
               fontWeight: '600',
               fontSize: '1.75rem',


### PR DESCRIPTION
In the tutorial, blockquotes have been used to prove additional information, rather than actually providing quoted text. Thus it does not make sense to add quotation marks to every blockquote.