### PR TITLE
Add solid-i18next package to Utilities

### DIFF
--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -644,6 +644,25 @@ const utilities: Array<Resource> = [
     type: ResourceType.Package,
     categories: [ResourceCategory.UI],
   },
+  {
+    link: 'https://github.com/mbarzda/solid-i18next',
+    title: 'solid-i18next',
+    description: 'Small library which covers i18next for Solid.',
+    author: 'Martynas Barzda',
+    author_url: 'https://github.com/mbarzda',
+    keywords: [
+      'i18n',
+      'i18next',
+      'localisation',
+      'localization',
+      'translate',
+      'translations',
+      'language',
+    ],
+    official: false,
+    type: ResourceType.Package,
+    categories: [ResourceCategory.UI, ResourceCategory.Data],
+  },
 ];
 
 export default utilities;


### PR DESCRIPTION
The purpose of this library is to provide ability to support i18next library in Solid applications with `<TranProvider />` and `<Trans />` components.