### PR TITLE
makrdown component: exclude children from passthrough properties

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -13,7 +13,7 @@ import 'prismjs/components/prism-bash';
 import 'prismjs/components/prism-typescript';
 
 const Markdown: Component<Props> = (props) => {
-  const [internal, external] = splitProps(props, ['class', 'onLoadSections']);
+  const [internal, external] = splitProps(props, ['class', 'onLoadSections', 'children']);
 
   const doc = createMemo(() => {
     const sections: Section[] = [];
@@ -28,7 +28,7 @@ const Markdown: Component<Props> = (props) => {
         },
       });
 
-    const html = md.render(props.children as string);
+    const html = md.render(internal.children as string);
 
     return {
       html,


### PR DESCRIPTION
This fixes part of the problem from https://github.com/solidjs/solid-site/issues/144 - if you click repeatedly on the 'Tutorial' nav button, it will render raw markdown source.

Markdown component receives markdown source as text in its `children`. If rendered `<div>` receives both rendered markdown in `innerHTML` and `children` from [`...external` passthrough](https://github.com/solidjs/solid-site/blob/master/src/components/Markdown.tsx#L46), it looks like the behavior is not deterministic, and it will render raw source from `children` sometimes. 