### PR TITLE
Re-add solid-i18next

### DIFF
--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -667,6 +667,24 @@ const utilities: Array<Resource> = [
     type: ResourceType.Package,
     categories: [ResourceCategory.UI],
   },
+  {
+    link: 'https://github.com/mbarzda/solid-i18next',
+    title: 'solid-i18next',
+    description: 'Small library which covers i18next for Solid.',
+    author: 'Martynas Barzda',
+    author_url: 'https://github.com/mbarzda',
+    keywords: [
+      'i18n',
+      'i18next',
+      'localization',
+      'translate',
+      'translations',
+      'language',
+    ],
+    official: false,
+    type: ResourceType.Package,
+    categories: [ResourceCategory.UI, ResourceCategory.Data],
+  },
 ];
 
 export default utilities;


### PR DESCRIPTION
Re-added solid-i18next, because it was removed during a merge or something