### PR TITLE
fix logo banner overflow

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -44,9 +44,9 @@ const Home: Component<{}> = () => {
       <header class="mx-2 rounded-br-3xl rounded-bl-3xl bg-gradient-to-r from-solid-light via-solid-medium to-solid-default text-white">
         <div class="md:bg-hero dark:from-bg-gray-700 bg-no-repeat bg-right rtl:bg-left px-10">
           <section class="px-3 lg:px-12 container space-y-10 lg:pb-20 lg:pt-52 py-10">
-            <div class="flex items-center space-y-4 lg:space-y-0 lg:space-x-4">
+            <div class="flex items-center w-[calc(100%+40px)] space-y-4 lg:space-y-0 lg:space-x-4">
               <img class="w-28 h-30 lg:w-48" src={logo} alt="Solid logo" />
-              <img class="w-52 h-15 lg:w-80" src={wordmark} alt="Solid wordmark" />
+              <img class="w-52 min-w-0 h-15 lg:w-80" src={wordmark} alt="Solid wordmark" />
             </div>
             <h2 class="lg:font-semibold text-3xl text-left lg:text-4xl leading-snug xl:max-w-4xl">
               {t('home.hero')}


### PR DESCRIPTION
Currently the logo banner overflows on smaller screens, such as mobile devices. The logo text is cut off and page body horizontal scroll is present.

![www solidjs com_(Moto G4) (1)](https://user-images.githubusercontent.com/29286430/136670882-d7cf662c-f010-4317-b3eb-030041c71e0f.png)

Here's the result after the fix. 
![localhost_3000_(Moto G4)](https://user-images.githubusercontent.com/29286430/136670935-1688b4bc-145a-4819-8f5d-3c4910dca41e.png)


