### PR TITLE
fix visual broken scroll shadows

### DIFF
--- a/src/components/ScrollShadow/ScrollShadow.tsx
+++ b/src/components/ScrollShadow/ScrollShadow.tsx
@@ -34,6 +34,7 @@ const ScrollShadow: Component<
     const target = e.currentTarget as HTMLElement;
     target.scrollLeft += e.deltaY;
   };
+
   onMount(() => {
     const resetInitShadowSize = () => {
       if (!initShadowSize) return;
@@ -97,11 +98,7 @@ const Sentinel: Component<Omit<TShared, 'shadowSize' | 'initShadowSize'>> = ({
     }: 0; height: 1px; width: 100%`;
   };
   const style = `pointer-events: none; ${setPosition(direction)}; `;
-  return (
-    <li>
-      <div style={style}></div>
-    </li>
-  );
+  return <div aria-hidden="true" style={style}></div>;
 };
 
 const Shadow: Component<{ ref: any } & TShared> = ({ child, direction, ref, shadowSize: size }) => {


### PR DESCRIPTION
A previous merge improved accessibility by wrapping scroll-shadow sentinels with `<li>` tags  #168 

However it broke the shadow behavior, so it was always left on even when scrolling at the very end, partially hiding last items in nav. 

It's fixed by removing `<li>` tags, and accessibility is kept by adding `aria-hidden` attribute on sentinel elements. Accessibility page score remains at 100%.

