### PR TITLE
fix tutorial overflow scrollbar

### DIFF
--- a/src/pages/Tutorial.tsx
+++ b/src/pages/Tutorial.tsx
@@ -191,7 +191,7 @@ const Tutorial: Component = () => {
         <div
           dir="ltr"
           class="md:grid"
-          style="height: calc(100vh - 60px); grid-template-columns: minmax(40%, 600px) auto"
+          style="height: calc(100vh - 64px); grid-template-columns: minmax(40%, 600px) auto"
         >
           <div class="flex flex-col bg-gray-50 h-full overflow-hidden border-r-2 border-grey mb-10 md:mb-0">
             <DirectoryMenu


### PR DESCRIPTION
Main content in tutorial is 4px bigger than viewport height, causing unnecessary vertical scrollbar.

 
![2021-10-13_14-38](https://user-images.githubusercontent.com/29286430/137217134-ca64ac6c-689f-4bc6-a3d8-f54294a44e81.png)
 