### PR TITLE
Fix/add scrollIntoView with active items

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,5 +1,5 @@
-import { Component, For, createMemo, createSignal, Show, onCleanup } from 'solid-js';
-import { Link, NavLink, useData } from 'solid-app-router';
+import { Component, For, createMemo, createSignal, Show, onMount } from 'solid-js';
+import { Link, NavLink } from 'solid-app-router';
 import { useI18n } from '@solid-primitives/i18n';
 import { createIntersectionObserver } from '@solid-primitives/intersection-observer';
 import logo from '../assets/logo.svg';
@@ -21,32 +21,45 @@ const langs = {
 
 type MenuLinkProps = { path: string; external?: boolean; title: string };
 
-const MenuLink: Component<MenuLinkProps> = (props) => (
-  <li>
-    <NavLink
-      href={props.path}
-      class="inline-flex items-center transition m-1 px-4 py-3 rounded pointer-fine:hover:text-white pointer-fine:hover:bg-solid-medium whitespace-nowrap"
-      activeClass="bg-solid-medium text-white"
-    >
-      <span>{props.title}</span>
-      <Show when={props.external}>
-        <svg
-          class="h-5 -mt-1 ltr:ml-1 rtl:mr-1 opacity-30"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-          />
-        </svg>
-      </Show>
-    </NavLink>
-  </li>
-);
+const MenuLink: Component<MenuLinkProps> = (props) => {
+  let linkEl!: HTMLAnchorElement;
+
+  onMount(() => {
+    if (!window.location.pathname.startsWith(props.path)) return;
+
+    setTimeout(() => {
+      linkEl.scrollIntoView({ inline: 'center' });
+    });
+  });
+
+  return (
+    <li>
+      <NavLink
+        href={props.path}
+        class="inline-flex items-center transition m-1 px-4 py-3 rounded pointer-fine:hover:text-white pointer-fine:hover:bg-solid-medium whitespace-nowrap"
+        activeClass="bg-solid-medium text-white"
+        ref={linkEl}
+      >
+        <span>{props.title}</span>
+        <Show when={props.external}>
+          <svg
+            class="h-5 -mt-1 ltr:ml-1 rtl:mr-1 opacity-30"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+            />
+          </svg>
+        </Show>
+      </NavLink>
+    </li>
+  );
+};
 
 const LanguageSelector: Component<{ onClick: () => void; class?: string }> = (props) => (
   <li class={props.class || ''}>

--- a/src/pages/Tutorial.tsx
+++ b/src/pages/Tutorial.tsx
@@ -73,7 +73,7 @@ const DirectoryMenu: Component<DirectoryMenuProps> = (props) => {
       document.documentElement.style.scrollBehavior = 'auto';
       document.body.clientWidth; // reflow
 
-      listContainer.querySelector('.js-active')?.scrollIntoView({ block: 'start' });
+      listContainer.querySelector('.js-active')?.scrollIntoView();
       window.scrollTo({ top: 0 });
       document.documentElement.style.scrollBehavior = 'smooth';
     }

--- a/src/pages/Tutorial.tsx
+++ b/src/pages/Tutorial.tsx
@@ -69,11 +69,13 @@ const DirectoryMenu: Component<DirectoryMenuProps> = (props) => {
 
   createEffect(() => {
     if (showDirectory()) {
-      // Focus the search input
       search.focus();
+      document.documentElement.style.scrollBehavior = 'auto';
+      document.body.clientWidth; // reflow
 
-      // Find the closest section and scroll it into the view
-      listContainer.querySelector('.js-active')?.scrollIntoView();
+      listContainer.querySelector('.js-active')?.scrollIntoView({ block: 'start' });
+      window.scrollTo({ top: 0 });
+      document.documentElement.style.scrollBehavior = 'smooth';
     }
   });
 


### PR DESCRIPTION
Add scrollIntoView behavior for active NavLinks for main Header.

Before:

https://user-images.githubusercontent.com/29286430/137408239-c46afc63-2971-4af1-97d2-fe83eac1ee18.mp4

After:

https://user-images.githubusercontent.com/29286430/137408587-9f459a7b-dd3a-418f-88bc-86e970602fc1.mp4



Fixed scrollIntoView behavior for Tutorial dropdown. It scrolls correctly for desktop, but for mobile it doesn't scroll to the active item at all. It could be due to the combination of the soft keyboard popping up and the page smooth scroll behavior it messing up.

Before:

https://user-images.githubusercontent.com/29286430/137408163-5af725ca-c484-4a97-9366-dfcf64a24466.mp4

After:

https://user-images.githubusercontent.com/29286430/137408624-a426d326-3a26-4dc3-9c62-51af547ab11b.mp4



