### PR TITLE
fix scroll shadow RTL and fallback logo position

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -100,13 +100,14 @@ const Nav: Component<{ showLogo?: boolean; filled?: boolean }> = (props) => {
           <ScrollShadow
             class="relative nav-items-container"
             direction="horizontal"
+            rtl={t('global.dir', {}, 'ltr') === 'rtl'}
             shadowSize="25%"
             initShadowSize={true}
           >
             <ul class="relative flex items-center overflow-auto no-scrollbar">
               <li
-                class="sticky z-10 left-0 nav-logo-bg dark:bg-solid-gray"
-                classList={{ 'pr-5': showLogo() }}
+                class="z-10 left-0 nav-logo-bg dark:bg-solid-gray"
+                classList={{ 'pr-5': showLogo(), sticky: t('global.dir', {}, 'ltr') === 'ltr' }}
               >
                 <Link href="/" class={`py-3 flex transition-all ${showLogo() ? 'w-9' : 'w-0'}`}>
                   <span class="sr-only">Navigate to the home page</span>

--- a/src/components/ScrollShadow/ScrollShadow.tsx
+++ b/src/components/ScrollShadow/ScrollShadow.tsx
@@ -3,6 +3,7 @@ import { Component, onCleanup, onMount } from 'solid-js';
 type TShared = {
   direction: 'horizontal' | 'vertical';
   child: 'first' | 'last';
+  rtl?: boolean;
   shadowSize: string;
   initShadowSize?: boolean;
 };
@@ -20,8 +21,12 @@ const ScrollShadow: Component<
   const sentinelShadowState = new Map<HTMLElement, HTMLElement>();
   let shadowFirstEl!: HTMLElement;
   let shadowLastEl!: HTMLElement;
-  let sentinelFirstEl = (<Sentinel child="first" direction={direction} />) as HTMLElement;
-  let sentinelLastEl = (<Sentinel child="last" direction={direction} />) as HTMLElement;
+  let sentinelFirstEl = (
+    <Sentinel child="first" direction={direction} rtl={props.rtl} />
+  ) as HTMLElement;
+  let sentinelLastEl = (
+    <Sentinel child="last" direction={direction} rtl={props.rtl} />
+  ) as HTMLElement;
   let init = true;
   let initResetSize = false;
 
@@ -49,7 +54,7 @@ const ScrollShadow: Component<
       if (!initShadowSize) return;
       sentinelShadowState.forEach((item) => {
         item.style.transform = 'scaleX(3)';
-        shadowLastEl.style.transformOrigin = 'right';
+        shadowLastEl.style.transformOrigin = props.rtl ? 'left' : 'right';
       });
     };
     const observer = new IntersectionObserver((entries) => {
@@ -65,6 +70,7 @@ const ScrollShadow: Component<
       });
       init = false;
     });
+
     scrollableContainer.addEventListener('wheel', scrollHorizontally, { passive: true });
     sentinelShadowState.set(sentinelFirstEl, shadowFirstEl);
     sentinelShadowState.set(sentinelLastEl, shadowLastEl);
@@ -75,46 +81,68 @@ const ScrollShadow: Component<
   });
   return (
     <div class={className}>
-      <Shadow child="first" direction={direction} shadowSize={shadowSize} ref={shadowFirstEl} />
-      <Shadow child="last" direction={direction} shadowSize={shadowSize} ref={shadowLastEl} />
+      <Shadow
+        child="first"
+        direction={direction}
+        shadowSize={shadowSize}
+        rtl={props.rtl}
+        ref={shadowFirstEl}
+      />
+      <Shadow
+        child="last"
+        direction={direction}
+        shadowSize={shadowSize}
+        rtl={props.rtl}
+        ref={shadowLastEl}
+      />
       {scrollableContainer}
     </div>
   );
 };
 
-const Sentinel: Component<Omit<TShared, 'shadowSize' | 'initShadowSize'>> = ({
-  direction,
-  child,
-}) => {
-  const setPosition = (direction: string) => {
+const Sentinel: Component<Omit<TShared, 'shadowSize' | 'initShadowSize'>> = (props) => {
+  const { direction, child } = props;
+
+  const setPosition = () => {
     const isFirst = child === 'first';
+    const rtl = props.rtl;
+    const marginLeft = rtl ? 'margin-right' : 'margin-left';
+    const left = rtl ? 'right' : 'left';
+    const right = rtl ? 'left' : 'right';
+
     if (direction === 'horizontal') {
       return `position: ${isFirst ? 'absolute' : 'static'}; top: 0; ${
-        isFirst ? 'left' : 'right'
-      }: 0; height: 100%; width: 1px; ${isFirst ? '' : 'flex-shrink: 0; margin-left: -1px;'}`;
+        isFirst ? left : right
+      }: 0; height: 100%; width: 1px; ${isFirst ? '' : `flex-shrink: 0; ${marginLeft}: -1px;`}`;
     }
     return `position: ${isFirst ? 'absolute' : 'relative'}; left: 0; ${
       isFirst ? 'top' : 'bottom'
     }: 0; height: 1px; width: 100%`;
   };
-  const style = `pointer-events: none; ${setPosition(direction)}; `;
-  return <div aria-hidden="true" style={style}></div>;
+  const style = () => `pointer-events: none; ${setPosition()}; `;
+  return <div aria-hidden="true" style={style()}></div>;
 };
 
-const Shadow: Component<{ ref: any } & TShared> = ({ child, direction, ref, shadowSize: size }) => {
+const Shadow: Component<{ ref: any } & TShared> = (props) => {
+  const { child, direction, ref, shadowSize: size } = props;
   const setPosition = () => {
     const isFirst = child === 'first';
+    const rtl = props.rtl;
+    const left = rtl ? 'right' : 'left';
+    const right = rtl ? 'left' : 'right';
+
     if (direction === 'horizontal') {
-      return `top: 0; ${isFirst ? 'left' : 'right'}: 0; background: linear-gradient(to ${
-        isFirst ? 'right' : 'left'
+      return `top: 0; ${isFirst ? left : right}: 0; background: linear-gradient(to ${
+        isFirst ? right : left
       }, rgba(255, 255, 255, 1), 50%, rgba(255, 255, 255, 0)); width: ${size}; height: 100%`;
     }
     return `left: 0; ${isFirst ? 'top' : 'bottom'}: 0; background: linear-gradient(to ${
       isFirst ? 'top' : 'bottom'
     }, rgba(255, 255, 255, 1), 50%, rgba(255, 255, 255, 0)); width: ${size}; height: 28%`;
   };
-  const style = `position: absolute; z-index: 1; pointer-events: none; transition: 300ms opacity, 300ms transform; ${setPosition()};`;
-  return <div ref={ref} style={style}></div>;
+  const style = () =>
+    `position: absolute; z-index: 1; pointer-events: none; transition: 300ms opacity, 300ms transform; ${setPosition()};`;
+  return <div ref={ref} style={style()}></div>;
 };
 
 export default ScrollShadow;


### PR DESCRIPTION
Scroll shadows due to RTL direction will be misplaced and activated in wrong ends.

![foobar](https://user-images.githubusercontent.com/29286430/137821084-a6d40b6a-e67e-4f03-b175-51ea4a0d75aa.png)

Also the logo disappears in mobile view. It's due to how the RTL messes up the CSS `postition: sticky` declaration.

![Peek 2021-10-18 16-38](https://user-images.githubusercontent.com/29286430/137820993-cc331b92-db9d-49bb-a1af-9a9c035df37f.gif)

I can't find a solution, so a temporary fix is removing `sticky` position if direction is RTL.
 
