### PR TITLE
dismiss language dropdown

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -5,6 +5,7 @@ import { createIntersectionObserver } from '@solid-primitives/intersection-obser
 import logo from '../assets/logo.svg';
 import ScrollShadow from './ScrollShadow/ScrollShadow';
 import Social from './Social';
+import Dismiss from 'solid-dismiss';
 
 const langs = {
   en: 'English',
@@ -62,11 +63,11 @@ const MenuLink: Component<MenuLinkProps> = (props) => {
   );
 };
 
-const LanguageSelector: Component<{ onClick: () => void; class?: string }> = (props) => (
+const LanguageSelector: Component<{ ref: HTMLButtonElement; class?: string }> = (props) => (
   <li class={props.class || ''}>
     <button
       aria-label="Select Language"
-      onClick={props.onClick}
+      ref={props.ref}
       class="dark:bg-solid-gray focus:color-red-500 bg-no-repeat bg-center hover:border-gray-500 cursor-pointer dark:border-dark px-6 pl-4 ml-5 rounded-md h-10 border border-solid-100 pt-4 text-sm my-3 w-full"
       style={{
         'background-image': 'url(/img/icons/translate2.svg)',
@@ -81,6 +82,9 @@ const Nav: Component<{ showLogo?: boolean; filled?: boolean }> = (props) => {
   const [locked, setLocked] = createSignal<boolean>(props.showLogo || true);
   const [t, { locale }] = useI18n();
   let firstLoad = true;
+  let langBtnTablet!: HTMLButtonElement;
+  let langBtnDesktop!: HTMLButtonElement;
+
   const [observer] = createIntersectionObserver([], ([entry]) => {
     if (firstLoad) {
       firstLoad = false;
@@ -89,6 +93,7 @@ const Nav: Component<{ showLogo?: boolean; filled?: boolean }> = (props) => {
     setLocked(entry.isIntersecting);
   });
   const showLogo = createMemo(() => props.showLogo || !locked());
+
   return (
     <>
       <div use:observer class="h-0" />
@@ -115,34 +120,37 @@ const Nav: Component<{ showLogo?: boolean; filled?: boolean }> = (props) => {
                 </Link>
               </li>
               <For each={t('global.nav')} children={MenuLink} />
-              <LanguageSelector onClick={() => toggleLangs(!showLangs())} class="flex lg:hidden" />
+              <LanguageSelector ref={langBtnTablet} class="flex lg:hidden" />
             </ul>
           </ScrollShadow>
           <ul class="hidden lg:flex items-center">
             <Social />
-            <LanguageSelector onClick={() => toggleLangs(!showLangs())} />
+            <LanguageSelector ref={langBtnDesktop} />
           </ul>
         </nav>
-        <Show when={showLangs()}>
-          <div class="container mx-auto bottom-0 bg-gray-200 absolute flex -mt-4 justify-end">
-            <div class="absolute mt-2 ltr:mr-5 rtl:ml-12 border rounded-md w-40 bg-white shadow-md">
-              <For each={Object.entries(langs)}>
-                {([lang, label]) => (
-                  <button
-                    class="first:rounded-t hover:bg-solid-lightgray last:rounded-b text-left p-3 text-sm border-b w-full"
-                    classList={{
-                      'bg-solid-medium text-white': lang == locale(),
-                      'hover:bg-solid-light': lang == locale(),
-                    }}
-                    onClick={() => locale(lang) && toggleLangs(false)}
-                  >
-                    {label}
-                  </button>
-                )}
-              </For>
-            </div>
+        <Dismiss
+          menuButton={[langBtnTablet, langBtnDesktop]}
+          open={showLangs}
+          setOpen={toggleLangs}
+          class="container mx-auto bottom-0 bg-gray-200 absolute flex -mt-4 justify-end"
+        >
+          <div class="absolute mt-2 ltr:mr-5 rtl:ml-12 border rounded-md w-40 bg-white shadow-md">
+            <For each={Object.entries(langs)}>
+              {([lang, label]) => (
+                <button
+                  class="first:rounded-t hover:bg-solid-lightgray last:rounded-b text-left p-3 text-sm border-b w-full"
+                  classList={{
+                    'bg-solid-medium text-white': lang == locale(),
+                    'hover:bg-solid-light': lang == locale(),
+                  }}
+                  onClick={() => locale(lang) && toggleLangs(false)}
+                >
+                  {label}
+                </button>
+              )}
+            </For>
           </div>
-        </Show>
+        </Dismiss>
       </div>
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5464,10 +5464,10 @@ solid-app-router@^0.1.5:
   resolved "https://registry.yarnpkg.com/solid-app-router/-/solid-app-router-0.1.5.tgz#565f128ba08796988e7dc736f680b82e547c22b2"
   integrity sha512-8wxpBP1pOea4rQFba1NH6uyPFBvqcSxHB4i9dSuoQw5OABgecvrFfAe+0TbYCP/7OhJ9RcEfsej+LBEdE/YS0Q==
 
-solid-dismiss@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/solid-dismiss/-/solid-dismiss-1.0.12.tgz#aa7b23bd1b0719af0a95f5d10a1d17c7786547b4"
-  integrity sha512-aAJHB1yqI4Y6DAL4gkKPiOOqqVeLsSIVV8YbkZBB7PYmQYWUObqGzqLzEgDWjufNQ8NyI5e60PXNmcTgOlrgxw==
+solid-dismiss@^1.0.14:
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/solid-dismiss/-/solid-dismiss-1.0.14.tgz#9923ef18b97ff498d04bcae65e1fd9f5231c5831"
+  integrity sha512-QMddRPKt3Es39XuNnevIFINzMty8sJ7Gl2bpFm+lV9zdqj0T18ED+OcxLzwad3paZW7TlKB8CXlLzkCzd5II7w==
 
 solid-js@0.26.5:
   version "0.26.5"


### PR DESCRIPTION
Added dismiss behavior to language dropdown.

![Peek 2021-10-19 22-35](https://user-images.githubusercontent.com/29286430/138034118-c83751dc-b925-44dd-abc7-8d9046f2fa5d.gif)

Dismiss package needs to be updated because there are two language buttons (one that renders in tablet size, and the other for desktop+) that open the same dropdown, so the new version handles that.
