### PR TITLE
Fix collapsed docs dropdown by setting to invisible

### DIFF
--- a/src/pages/Docs.tsx
+++ b/src/pages/Docs.tsx
@@ -123,6 +123,7 @@ const Docs: Component = (props) => {
                           class="overflow-hidden transition"
                           classList={{
                             'h-0': section[firstLevel.title] !== true,
+                            invisible: section[firstLevel.title] !== true,
                             'h-full': section[firstLevel.title],
                           }}
                         >


### PR DESCRIPTION
Currently the collapsed dropdown items are still accessible to  keyboard, so when tabbing, user won't see what's active.

![tabbing-invisble](https://user-images.githubusercontent.com/29286430/138179698-b1c1eb53-a042-4cd4-8542-d046c0524f26.gif)

To fix this, using tailwinds `invisble` which uses CSS `visibility:hidden;` declaration, which basically keeps element size, but hides it visually and removes it from accessibility tree.

![tabbing-ignore-invisble](https://user-images.githubusercontent.com/29286430/138180008-75e2b998-9b5b-4d16-8946-69508c93a1ee.gif)

