### PR TITLE
minor visual improvements/fixes

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -76,6 +76,7 @@
   border-radius: 3px;
 }
 .chevron::after {
+  @apply border-gray-300;
   border-style: solid;
   transition: all 250ms;
   border-width: 0.15em 0.15em 0 0;
@@ -90,12 +91,12 @@
 }
 .chevron.chevron-right:after {
   left: 0.25em;
-  top: 0.55em;
+  top: 0.43em;
   transform: rotate(45deg);
 }
 .chevron.chevron-left:after {
   right: 0.25em;
-  top: 0.55em;
+  top: 0.43em;
   transform: rotate(225deg);
 }
 .chevron.chevron-right:hover::after {

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -39,7 +39,7 @@ const MenuLink: Component<MenuLinkProps> = (props) => {
       <NavLink
         href={props.path}
         class="inline-flex items-center transition m-1 px-4 py-3 rounded pointer-fine:hover:text-white pointer-fine:hover:bg-solid-medium whitespace-nowrap"
-        activeClass="bg-solid-medium text-white"
+        activeClass="bg-solid-medium text-white pointer-fine:group-hover:bg-solid-default"
         ref={linkEl}
       >
         <span>{props.title}</span>
@@ -103,7 +103,7 @@ const Nav: Component<{ showLogo?: boolean; filled?: boolean }> = (props) => {
       >
         <nav class="px-3 lg:px-12 container lg:flex justify-between items-center max-h-18 relative z-20 space-x-10">
           <ScrollShadow
-            class="relative nav-items-container"
+            class="group relative nav-items-container"
             direction="horizontal"
             rtl={t('global.dir', {}, 'ltr') === 'rtl'}
             shadowSize="25%"
@@ -111,8 +111,12 @@ const Nav: Component<{ showLogo?: boolean; filled?: boolean }> = (props) => {
           >
             <ul class="relative flex items-center overflow-auto no-scrollbar">
               <li
-                class="z-10 left-0 nav-logo-bg dark:bg-solid-gray"
-                classList={{ 'pr-5': showLogo(), sticky: t('global.dir', {}, 'ltr') === 'ltr' }}
+                class="left-0 nav-logo-bg dark:bg-solid-gray"
+                classList={{
+                  'pr-5': showLogo(),
+                  sticky: t('global.dir', {}, 'ltr') === 'ltr',
+                  'z-10': t('global.dir', {}, 'ltr') === 'ltr',
+                }}
               >
                 <Link href="/" class={`py-3 flex transition-all ${showLogo() ? 'w-9' : 'w-0'}`}>
                   <span class="sr-only">Navigate to the home page</span>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -158,8 +158,11 @@ render(() => <CountingComponent />, document.getElementById("app"));`,
             </Link>
           </div>
         </section>
-        <section class="dark:bg-gray-500 bg-gray-50 py-20 grid grid-cols-1 lg:grid-cols-2 px-5 lg:px-20 defer rounded-br-6xl lg:bg-blocks-three bg-no-repeat bg-contain bg-right rtl:bg-left">
-          <div class="px-5">
+        <section class="dark:bg-gray-500 bg-gray-50 py-16 grid grid-cols-1 lg:grid-cols-2 px-5 lg:px-16 defer rounded-br-6xl lg:bg-blocks-three bg-no-repeat bg-contain bg-right rtl:bg-left">
+          <div
+            class="px-9 py-4 bg-gray-50 2xl:bg-opacity-0 bg-opacity-80 rounded-lg"
+            classList={{ 'xl:bg-opacity-0': t('global.dir', {}, 'ltr') === 'ltr' }}
+          >
             <img class="w-16" src={sandbox} alt="" />
             <h2 class="text-3xl mt-8 mb-5 text-solid font-semibold">
               {t('home.reactivity.headline')}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -73,5 +73,10 @@ module.exports = {
       },
     },
   },
+  variants: {
+    extend: {
+      backgroundColor: ['group-hover'],
+    },
+  },
   plugins: [require('@tailwindcss/typography'), require('tailwindcss-dir')],
 };


### PR DESCRIPTION
## Scroll shadow hidding Logo

Fixed scroll shadow to obscure logo when RTL is active
![logo-covered](https://user-images.githubusercontent.com/29286430/138263562-a995bcd0-5e07-483f-98fc-706247906fa6.png)

## Improve chevron position

Chevrons was a little below text baseline, so new ones are nudged higher, and increased darkening color but kept subtlety since that tends to be theme of this site.
![chevrons](https://user-images.githubusercontent.com/29286430/138264081-88229440-ce1e-473d-96fd-32a588b5360c.png)

## Hover active nav-item
Darken active nav-item when other nav items are hovered for extra clarity on which is active and which is hovered.

Before:
![Peek 2021-10-21 03-19](https://user-images.githubusercontent.com/29286430/138265030-358c9967-057f-4295-be2b-c89a953cd98f.gif)
After:
![Peek 2021-10-21 03-18](https://user-images.githubusercontent.com/29286430/138264870-0fe31238-a7ea-4d36-9c5f-531993671f5e.gif)

## Background with partial opacity for particular text section

Improve "Fine Grained" section to be more readable when graphic is directly behind text. This is done by adding light grey background with partial opacity.
![bg-opacity](https://user-images.githubusercontent.com/29286430/138263641-d7680bf1-e556-4210-b4c2-33ec31286aff.png)

I made sure this new background is removed for larger layout to keep that "seamless" effect.

![Screenshot from 2021-10-21 02-27-36](https://user-images.githubusercontent.com/29286430/138265653-01b6aae5-a982-4151-b5ba-241d001a5df4.png)




