### PR TITLE
splash header is smaller and navlinks smaller on mobile devices

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,12 +1,4 @@
-import {
-  Component,
-  Switch,
-  Match,
-  Show,
-  on,
-  createEffect,
-  createSignal,
-} from 'solid-js';
+import { Component, Switch, Match, Show, on, createEffect, createSignal } from 'solid-js';
 import { Transition } from 'solid-transition-group';
 import { useI18n } from '@solid-primitives/i18n';
 import { useLocation } from 'solid-app-router';
@@ -59,10 +51,15 @@ const Header: Component<{ title?: string }> = () => {
             <div class="md:bg-hero dark:from-bg-gray-700 bg-no-repeat bg-right rtl:bg-left px-10">
               <section class="px-3 lg:px-12 container space-y-10 lg:pb-20 lg:pt-52 py-10">
                 <div class="flex items-center w-[calc(100%+40px)] space-y-4 lg:space-y-0 lg:space-x-4">
-                  <img class="w-28 h-30 lg:w-48" src={logo} alt="Solid logo" />
+                  <img
+                    class="w-[6rem] h-30 lg:w-48"
+                    style="filter: drop-shadow(-10px 4px 8px rgb(0 22 100 / 10%))"
+                    src={logo}
+                    alt="Solid logo"
+                  />
                   <img class="w-52 min-w-0 h-15 lg:w-80" src={wordmark} alt="Solid wordmark" />
                 </div>
-                <h2 class="lg:font-semibold text-3xl lg:text-4xl leading-snug xl:max-w-4xl">
+                <h2 class="lg:font-semibold text-[26px] sm:text-3xl leading-10 lg:text-4xl sm:leading-snug xl:max-w-4xl">
                   {t('home.hero')}
                 </h2>
               </section>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -15,9 +15,9 @@ import logo from '../assets/logo.svg';
 import ScrollShadow from './ScrollShadow/ScrollShadow';
 import Social from './Social';
 import Dismiss from 'solid-dismiss';
+import { reflow } from '../utils';
 import { routeReadyState, setRouteReadyState } from '../utils/routeReadyState';
 import PageLoadingBar from './LoadingBar/PageLoadingBar';
-import { reflow } from '../utils';
 
 const langs = {
   en: 'English',
@@ -31,7 +31,6 @@ const langs = {
   id: 'Bahasa Indonesia',
   he: 'עִברִית',
   fa: 'فارسی',
-  tr: 'Türkçe',
 };
 
 type MenuLinkProps = { path: string; external?: boolean; title: string };
@@ -51,7 +50,7 @@ const MenuLink: Component<MenuLinkProps> = (props) => {
     <li>
       <NavLink
         href={props.path}
-        class="inline-flex items-center transition m-1 px-4 py-3 rounded pointer-fine:hover:text-white pointer-fine:hover:bg-solid-medium whitespace-nowrap"
+        class="inline-flex items-center transition text-[15px] sm:text-base m-0 sm:m-1 px-3 sm:px-4 py-3 rounded pointer-fine:hover:text-white pointer-fine:hover:bg-solid-medium whitespace-nowrap"
         activeClass="bg-solid-medium text-white pointer-fine:group-hover:bg-solid-default"
         onClick={() => {
           const pageEl = document.body;
@@ -141,7 +140,7 @@ const Nav: Component<{ showLogo?: boolean; filled?: boolean }> = (props) => {
     <>
       <div use:observer class="h-0" />
       <div
-        class="flex justify-center sticky top-0 z-50 dark:bg-solid-gray bg-white"
+        class="flex justify-center sticky top-0 z-50 dark:bg-solid-gray bg-white overflow-hidden"
         classList={{ 'shadow-md': showLogo() }}
       >
         <Show when={showLogo() && routeReadyState().loading}>


### PR DESCRIPTION
For mobile view, Navlinks are smaller (15px) in order for the user to see at least 4 links as opposed to 3. Splash header text is smaller as well as the logo, in order to bring a more balanced look.

![big-header](https://user-images.githubusercontent.com/29286430/140436560-6f7ab076-83b0-4f63-9731-2c1c659391c8.png)
