### PR TITLE
fix Nav bar language switch to make text easier to read when hovering over it.

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -310,7 +310,7 @@ const Nav: Component<{ showLogo?: boolean; filled?: boolean }> = (props) => {
             <For each={Object.entries(langs)}>
               {([lang, label]) => (
                 <button
-                  class="first:rounded-t hover:bg-solid-gray last:rounded-b text-left p-3 text-sm border-b w-full"
+                  class="first:rounded-t hover:bg-solid-gray hover:text-white last:rounded-b text-left p-3 text-sm border-b w-full"
                   classList={{
                     'bg-solid-medium text-white': lang == locale(),
                     'hover:bg-solid-light': lang == locale(),


### PR DESCRIPTION
…
## Before
<img width="360" alt="screenshot 2022-01-21 11 47 16" src="https://user-images.githubusercontent.com/44772513/150457402-d61efccc-957d-4021-a9f4-95bc1c8dc311.png">

## After

<img width="251" alt="screenshot 2022-01-21 11 47 03" src="https://user-images.githubusercontent.com/44772513/150457563-74c792f5-8a3c-4199-999d-4abe2d0e8d62.png">

