### PR TITLE
Dark mode (again)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,8 @@
-import { Component, Suspense } from 'solid-js';
-import { Title, Meta } from 'solid-meta';
+import { Suspense } from 'solid-js';
 import { useRoutes, Router } from 'solid-app-router';
 import { routes } from './routes';
 import Header from './components/Header';
-import { AppContextProvider, useAppContext } from './AppContext';
-import { I18nContext } from '@solid-primitives/i18n';
+import { AppContextProvider } from './AppContext';
 import { preventSmoothScrollOnTabbing } from './utils';
 
 export const App = () => {
@@ -16,33 +14,19 @@ export const App = () => {
     <main class="min-h-screen">
       <Router>
         <AppContextProvider>
-          <Lang>
-            <Header />
-            {/* two div wrappers to make page animation work and performant */}
-            <div id="main-content">
-              <div>
-                {/* <TransitionRoutes> */}
-                <Suspense>
-                  <Routes />
-                </Suspense>
-                {/* </TransitionRoutes> */}
-              </div>
+          <Header />
+          {/* two div wrappers to make page animation work and performant */}
+          <div id="main-content">
+            <div>
+              {/* <TransitionRoutes> */}
+              <Suspense>
+                <Routes />
+              </Suspense>
+              {/* </TransitionRoutes> */}
             </div>
-          </Lang>
+          </div>
         </AppContextProvider>
       </Router>
     </main>
-  );
-};
-
-const Lang: Component = (props) => {
-  const context = useAppContext();
-  const [t, { locale }] = context.i18n;
-  return (
-    <I18nContext.Provider value={context.i18n}>
-      <Title>{t('global.title', {}, 'SolidJS · Reactive Javascript Library')}</Title>
-      <Meta name="lang" content={locale()} />
-      <div dir={t('global.dir', {}, 'ltr')}>{props.children}</div>
-    </I18nContext.Provider>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,10 @@
 import { Component, Suspense } from 'solid-js';
 import { Title, Meta } from 'solid-meta';
-import { useRoutes, Router, useData } from 'solid-app-router';
+import { useRoutes, Router } from 'solid-app-router';
 import { routes } from './routes';
 import Header from './components/Header';
-import { AppData } from './App.data';
-import { I18nContext, createI18nContext } from '@solid-primitives/i18n';
+import { AppContextProvider, useAppContext } from './AppContext';
+import { I18nContext } from '@solid-primitives/i18n';
 import { preventSmoothScrollOnTabbing } from './utils';
 
 export const App = () => {
@@ -14,30 +14,32 @@ export const App = () => {
 
   return (
     <main class="min-h-screen">
-      <Router data={AppData}>
-        <Lang>
-          <Header />
-          {/* two div wrappers to make page animation work and performant */}
-          <div id="main-content">
-            <div>
-              {/* <TransitionRoutes> */}
-              <Suspense>
-                <Routes />
-              </Suspense>
-              {/* </TransitionRoutes> */}
+      <Router>
+        <AppContextProvider>
+          <Lang>
+            <Header />
+            {/* two div wrappers to make page animation work and performant */}
+            <div id="main-content">
+              <div>
+                {/* <TransitionRoutes> */}
+                <Suspense>
+                  <Routes />
+                </Suspense>
+                {/* </TransitionRoutes> */}
+              </div>
             </div>
-          </div>
-        </Lang>
+          </Lang>
+        </AppContextProvider>
       </Router>
     </main>
   );
 };
 
 const Lang: Component = (props) => {
-  const data = useData<{ i18n: ReturnType<typeof createI18nContext> }>(0);
-  const [t, { locale }] = data.i18n;
+  const context = useAppContext();
+  const [t, { locale }] = context.i18n;
   return (
-    <I18nContext.Provider value={data.i18n}>
+    <I18nContext.Provider value={context.i18n}>
       <Title>{t('global.title', {}, 'SolidJS · Reactive Javascript Library')}</Title>
       <Meta name="lang" content={locale()} />
       <div dir={t('global.dir', {}, 'ltr')}>{props.children}</div>

--- a/src/AppContext.tsx
+++ b/src/AppContext.tsx
@@ -1,8 +1,24 @@
-import { createEffect, createResource } from 'solid-js';
-import { RouteDataFunc } from 'solid-app-router';
+import { Component, createContext, createEffect, createResource, useContext } from 'solid-js';
+import { useLocation } from 'solid-app-router';
 import createCookieStore from '@solid-primitives/cookies-store';
 import { createI18nContext } from '@solid-primitives/i18n';
-import { getGuides, getSupported } from '@solid.js/docs';
+import { getGuides, getSupported, ResourceMetadata } from '@solid.js/docs';
+
+interface AppContextInterface {
+  isDark: boolean,
+  loading: boolean,
+  guidesSupported: boolean,
+  guides: ResourceMetadata[] | undefined,
+  i18n: ReturnType<typeof createI18nContext>,
+}
+
+const AppContext = createContext<AppContextInterface>({
+  isDark: false,
+  loading: true,
+  guidesSupported: false,
+  guides: undefined,
+  i18n: undefined as unknown as ReturnType<typeof createI18nContext>,
+});
 
 const langs: { [lang: string]: any } = {
   en: async () => (await import('../lang/en/en')).default(),
@@ -33,15 +49,15 @@ type DataParams = {
   page: string;
 };
 
-export const AppData: RouteDataFunc = (props) => {
+export const AppContextProvider: Component<{}> = (props) => {
   const now = new Date();
   const [settings, set] = createCookieStore<{ dark: string; locale: string }>(undefined, {
     expires: new Date(now.getFullYear() + 1, now.getMonth(), now.getDate()),
   });
-  // const userMedia = window.matchMedia('(prefers-color-scheme: dark)');
   const browserLang = navigator.language.slice(0, 2);
-  if (props.location.query.locale) {
-    set('locale', props.location.query.locale);
+  const location = useLocation();
+  if (location.query.locale) {
+    set('locale', location.query.locale);
   } else if (!settings.locale && langs.hasOwnProperty(browserLang)) {
     set('locale', browserLang);
   }
@@ -49,7 +65,7 @@ export const AppData: RouteDataFunc = (props) => {
   const [, { add }] = i18n;
   const params = (): DataParams => {
     const locale = i18n[1].locale();
-    let page = props.location.pathname.slice(1);
+    let page = location.pathname.slice(1);
     if (page == '') {
       page = 'home';
     }
@@ -61,7 +77,10 @@ export const AppData: RouteDataFunc = (props) => {
 
   const [lang] = createResource(params, ({ locale }) => langs[locale]());
   const [guidesList] = createResource(params, ({ locale }) => getGuides(locale, true));
-  const isDark = () => false; //settings.dark === 'true' ? true : settings.dark === 'false' ? false : userMedia.matches;
+  const isDark = () =>
+    settings.dark === 'true' ? true :
+    settings.dark === 'false' ? false :
+    window.matchMedia('(prefers-color-scheme: dark)').matches;
 
   createEffect(() => set('locale', i18n[1].locale()));
   createEffect(() => {
@@ -72,7 +91,7 @@ export const AppData: RouteDataFunc = (props) => {
     else document.documentElement.classList.remove('dark');
   });
 
-  return {
+  const store = {
     set isDark(value) {
       set('dark', value === true ? 'true' : 'false');
     },
@@ -97,4 +116,12 @@ export const AppData: RouteDataFunc = (props) => {
       return guidesList();
     },
   };
+
+  return (
+    <AppContext.Provider value={store}>
+      {props.children}
+    </AppContext.Provider>
+  );
 };
+
+export const useAppContext = () => useContext(AppContext);

--- a/src/AppContext.tsx
+++ b/src/AppContext.tsx
@@ -1,7 +1,8 @@
 import { Component, createContext, createEffect, createResource, useContext } from 'solid-js';
+import { Meta, Title } from 'solid-meta';
 import { useLocation } from 'solid-app-router';
 import createCookieStore from '@solid-primitives/cookies-store';
-import { createI18nContext } from '@solid-primitives/i18n';
+import { createI18nContext, I18nContext } from '@solid-primitives/i18n';
 import { getGuides, getSupported, ResourceMetadata } from '@solid.js/docs';
 
 interface AppContextInterface {
@@ -9,7 +10,6 @@ interface AppContextInterface {
   loading: boolean,
   guidesSupported: boolean,
   guides: ResourceMetadata[] | undefined,
-  i18n: ReturnType<typeof createI18nContext>,
 }
 
 const AppContext = createContext<AppContextInterface>({
@@ -17,7 +17,6 @@ const AppContext = createContext<AppContextInterface>({
   loading: true,
   guidesSupported: false,
   guides: undefined,
-  i18n: undefined as unknown as ReturnType<typeof createI18nContext>,
 });
 
 const langs: { [lang: string]: any } = {
@@ -62,7 +61,7 @@ export const AppContextProvider: Component<{}> = (props) => {
     set('locale', browserLang);
   }
   const i18n = createI18nContext({}, settings.locale || 'en');
-  const [, { add }] = i18n;
+  const [t, { add, locale }] = i18n;
   const params = (): DataParams => {
     const locale = i18n[1].locale();
     let page = location.pathname.slice(1);
@@ -98,9 +97,6 @@ export const AppContextProvider: Component<{}> = (props) => {
     get isDark() {
       return isDark();
     },
-    get i18n() {
-      return i18n;
-    },
     get loading() {
       return lang.loading;
     },
@@ -119,7 +115,13 @@ export const AppContextProvider: Component<{}> = (props) => {
 
   return (
     <AppContext.Provider value={store}>
-      {props.children}
+      <I18nContext.Provider value={i18n}>
+        <Title>{t('global.title', {}, 'SolidJS · Reactive Javascript Library')}</Title>
+        <Meta name="lang" content={locale()} />
+        <div dir={t('global.dir', {}, 'ltr')}>
+          {props.children}
+        </div>
+      </I18nContext.Provider>
     </AppContext.Provider>
   );
 };

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -73,7 +73,7 @@ const Footer: Component = () => {
             <div class="flex justify-between">
               <p class="text-sm text-center text-gray-600 dark:text-gray-300">
                 {t('global.footer.updated', {
-                  date: '2022/01/21, 9:30am',
+                  date: '2022/01/27, 9:00am',
                   version: '1.3.3',
                 })}
               </p>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,9 +1,9 @@
-import type { Component } from 'solid-js';
+import { Component } from 'solid-js';
 import { Portal } from 'solid-js/web';
-// import { useData } from 'solid-app-router';
 import Newsletter from './Newsletter';
 import { useI18n } from '@solid-primitives/i18n';
-// import darkLight from '../assets/icons/dark-light.svg';
+import { useAppContext } from '../AppContext';
+import darkLight from '../assets/icons/dark-light.svg';
 import wordmark from '../assets/wordmark-dark.svg';
 import builder from '../assets/supporters/builder.png';
 import sauce from '../assets/supporters/saucelabs.png';
@@ -13,7 +13,7 @@ import Social from './Social';
 
 const Footer: Component = () => {
   const [t] = useI18n();
-  // const data = useData<{ isDark: true }>(-1);
+  const context = useAppContext();
   return (
     <Portal mount={document.getElementById('footer')!}>
       <div
@@ -77,14 +77,14 @@ const Footer: Component = () => {
                   version: '1.3.3',
                 })}
               </p>
-              {/* <button
+              {<button
                 class="flex text-gray-600 dark:text-gray-300"
-                onClick={() => (data.isDark = !data.isDark)}
+                onClick={() => (context.isDark = !context.isDark)}
               >
                 <img class="w-5 dark:invert" src={darkLight} />
                 &nbsp;
-                {data.isDark ? 'Disable dark mode' : 'Enable dark mode'}
-              </button> */}
+                {context.isDark ? 'Disable dark mode' : 'Enable dark mode'}
+              </button>}
             </div>
             <ul class="lg:hidden flex justify-center items-center pt-12 space-x-3">
               <Social />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,14 +10,14 @@ import {
 } from 'solid-js';
 import { Transition } from 'solid-transition-group';
 import { useI18n } from '@solid-primitives/i18n';
-import { useData, useLocation } from 'solid-app-router';
+import { useLocation } from 'solid-app-router';
 import Nav from './Nav';
+import { useAppContext } from '../AppContext';
 import logo from '../assets/logo.svg';
 import wordmark from '../assets/wordmark.svg';
 import { reflow } from '../utils';
 import PageLoadingBar from './LoadingBar/PageLoadingBar';
 import { routeReadyState, page } from '../utils/routeReadyState';
-import { ResourceMetadata } from '@solid.js/docs';
 
 const Header: Component<{ title?: string }> = () => {
   const [t] = useI18n();
@@ -28,12 +28,12 @@ const Header: Component<{ title?: string }> = () => {
   const [showHeaderSmall, setShowHeaderSmall] = createSignal(noSmallHeader);
   const [showHeaderSplash, setShowHeaderSplash] = createSignal(isHome);
 
-  const data = useData<{ guides: ResourceMetadata[] | undefined }>();
+  const context = useAppContext();
 
   const guideName = createMemo(() => {
-    if (data?.guides) {
+    if (context.guides) {
       const resource = location.pathname.slice(1);
-      return data?.guides.find((metadata) => metadata.resource == resource)?.title;
+      return context.guides.find((metadata) => metadata.resource == resource)?.title;
     }
   });
 

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -9,9 +9,7 @@ import {
   createComputed,
   batch,
 } from 'solid-js';
-import { useData } from 'solid-app-router';
 import { Link, NavLink } from 'solid-app-router';
-import { ResourceMetadata } from '@solid.js/docs';
 import { useI18n } from '@solid-primitives/i18n';
 import { createIntersectionObserver } from '@solid-primitives/intersection-observer';
 import { createEventListener } from '@solid-primitives/event-listener';
@@ -20,6 +18,7 @@ import Dismiss from 'solid-dismiss';
 import logo from '../assets/logo.svg';
 import ScrollShadow from './ScrollShadow/ScrollShadow';
 import Social from './Social';
+import { useAppContext } from '../AppContext';
 import { reflow } from '../utils';
 import { routeReadyState, page, setRouteReadyState } from '../utils/routeReadyState';
 import PageLoadingBar from './LoadingBar/PageLoadingBar';
@@ -162,7 +161,7 @@ const Nav: Component<{ showLogo?: boolean; filled?: boolean }> = (props) => {
   const [locked, setLocked] = createSignal<boolean>(props.showLogo || true);
   const [closeSubnav, clearSubnavClose] = createDebounce(() => setSubnav([]), 150);
   const [t, { locale }] = useI18n();
-  const data = useData<{ guides: ResourceMetadata[] | undefined; guidesSupported: boolean }>();
+  const context = useAppContext();
 
   let firstLoad = true;
   let langBtnTablet!: HTMLButtonElement;
@@ -193,15 +192,15 @@ const Nav: Component<{ showLogo?: boolean; filled?: boolean }> = (props) => {
   const showLogo = createMemo(() => props.showLogo || !locked());
   const navList = createMemo<MenuLinkProps[]>(
     on(
-      () => [locale, t('global.nav'), data.guides],
+      () => [locale, t('global.nav'), context.guides],
       () => {
         return (t('global.nav') || []).reduce((memo: any, item: any) => {
           let itm = { ...item };
           // Inject guides if available
           if (item.path == '/guides') {
-            if (data.guides?.length) {
-              const direction = data.guidesSupported ? t('global.dir', {}, 'ltr') : 'ltr';
-              itm.links = data.guides.map(({ title, description, resource }) => ({
+            if (context.guides?.length) {
+              const direction = context.guidesSupported ? t('global.dir', {}, 'ltr') : 'ltr';
+              itm.links = context.guides.map(({ title, description, resource }) => ({
                 title,
                 description,
                 direction,

--- a/src/components/ReplTab.tsx
+++ b/src/components/ReplTab.tsx
@@ -1,12 +1,12 @@
 import { Component, createSignal, ErrorBoundary } from 'solid-js';
-import { useData } from 'solid-app-router';
 import { createTabList, Repl, Tab } from 'solid-repl';
 import { compiler, formatter } from './setupRepl';
+import { useAppContext } from '../AppContext';
 
 let count = 0;
 const OldRepl: Component<{ tabs: Tab[] }> = (props) => {
   count++;
-  const data = useData<{ isDark: true }>(-1);
+  const context = useAppContext();
   const initialTabs = props.tabs || [
     {
       name: 'main',
@@ -30,7 +30,7 @@ const OldRepl: Component<{ tabs: Tab[] }> = (props) => {
         interactive={true}
         actionBar={true}
         editableTabs={true}
-        dark={data.isDark}
+        dark={context.isDark}
         tabs={tabs()}
         setTabs={setTabs}
         current={current()}

--- a/src/components/ScrollShadow/ScrollShadow.tsx
+++ b/src/components/ScrollShadow/ScrollShadow.tsx
@@ -1,5 +1,5 @@
 import { Component, onCleanup, onMount } from 'solid-js';
-import { useData } from 'solid-app-router';
+import { useAppContext } from '../../AppContext';
 
 type TShared = {
   direction: 'horizontal' | 'vertical';
@@ -125,7 +125,7 @@ const Sentinel: Component<
 
 const Shadow: Component<{ ref: any } & TShared> = (props) => {
   const { child, direction, ref, shadowSize: size } = props;
-  const data = useData<{ isDark: true }>(-1);
+  const context = useAppContext();
   const refCb = (el: HTMLElement) => {
     ref(el);
     divEl = el;
@@ -137,7 +137,7 @@ const Shadow: Component<{ ref: any } & TShared> = (props) => {
     const rtl = props.rtl;
     const left = rtl ? 'right' : 'left';
     const right = rtl ? 'left' : 'right';
-    const rgb = data.isDark ? '0, 0, 0' : '255, 255, 255';
+    const rgb = context.isDark ? '0, 0, 0' : '255, 255, 255';
 
     if (direction === 'horizontal') {
       return `top: 0; ${isFirst ? left : right}: 0; background: linear-gradient(to ${

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -6,10 +6,11 @@ import { ExamplesDataRoute } from './Examples.data';
 import { compiler, formatter } from '../components/setupRepl';
 import { useI18n } from '@solid-primitives/i18n';
 import { useRouteReadyState } from '../utils/routeReadyState';
+import { useAppContext } from '../AppContext';
 
 const Examples: Component = () => {
   const data = useData<ExamplesDataRoute>();
-  const rootData = useData<{ isDark: true }>(-1);
+  const context = useAppContext();
   const [t] = useI18n();
   const params = useParams<{ id: string }>();
   const [tabs, setTabs] = createTabList([
@@ -98,7 +99,7 @@ const Examples: Component = () => {
                 interactive={true}
                 actionBar={true}
                 editableTabs={true}
-                dark={rootData.isDark}
+                dark={context.isDark}
                 tabs={tabs()}
                 setTabs={setTabs}
                 current={current()}

--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -1038,8 +1038,7 @@ const utilities: Array<Resource> = [
   {
     link: 'https://github.com/jherr/chrome-extension-boilerplate-solid',
     title: 'chrome-extension-boilerplate-solid',
-    description:
-      'Chrome Extensions boilerplate with SolidJS',
+    description: 'Chrome Extensions boilerplate with SolidJS',
     author: 'hjerr',
     author_url: 'https://github.com/jherr',
     keywords: ['chrome', 'extension', 'plugin'],

--- a/src/pages/Tutorial.tsx
+++ b/src/pages/Tutorial.tsx
@@ -26,6 +26,7 @@ import { useI18n } from '@solid-primitives/i18n';
 import Dismiss from 'solid-dismiss';
 import { useRouteReadyState } from '../utils/routeReadyState';
 import SolidMarkdown from 'solid-markdown';
+import { useAppContext } from '../AppContext';
 
 const alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
 
@@ -156,7 +157,7 @@ const DirectoryMenu: Component<DirectoryMenuProps> = (props) => {
 
 const Tutorial: Component = () => {
   const data = useData<TutorialRouteData>();
-  const rootData = useData<{ isDark: true }>(-1);
+  const context = useAppContext();
   const [t] = useI18n();
   let replEditor: any;
   const [tabs, setTabs] = createTabList([
@@ -280,7 +281,7 @@ const Tutorial: Component = () => {
               interactive={true}
               actionBar={true}
               editableTabs={true}
-              dark={rootData.isDark}
+              dark={context.isDark}
               tabs={tabs()}
               setTabs={setTabs}
               current={current()}


### PR DESCRIPTION
The goal of this PR is to re-enable dark mode introduced in #221. To achieve this, it makes two structural changes:

* Top-level `AppData` converted into `AppContext` which is a regular `createContext`. This makes it available in all routes, no matter how deep, without needing [negative data indexing](https://github.com/solidjs/solid-app-router/pull/69).
  * This seems to be the approach that `solid-app-router` is moving toward (as discussed in `#next`): for global stuff, use context; that's what it's for.
* Also combined the new `AppContext` with the existing `Lang` context provider, as this was the only place `i18n` was getting used and it seemed to make sense all together. (This is in a separate commit.)

See #221 for dark-mode screenshots. I've tested language switching and flipping through all the pages, though perhaps there are more tests to do?