### PR TITLE
Move z-20 class to fix stacking contexts

### DIFF
--- a/src/pages/Docs.tsx
+++ b/src/pages/Docs.tsx
@@ -142,7 +142,7 @@ const Docs: Component<{ hash?: string }> = (props) => {
     <div dir="ltr" class="lg:bg-doc dark:lg:bg-darkDoc flex min-h-screen flex-auto relative">
       <Show when={data.doc}>
         <div class="flex container">
-          <div class="absolute left-0 h-full lg:static lg:w-3/12 bg-gray-100 dark:bg-gray-900 rounded-br-lg">
+          <div class="absolute z-20 left-0 h-full lg:static lg:w-3/12 bg-gray-100 dark:bg-gray-900 rounded-br-lg">
             <button
               class={
                 'fixed lg:hidden top-20 right-3 text-white rounded-lg pl-1 pt-1 transition duration-500 ' +
@@ -165,7 +165,7 @@ const Docs: Component<{ hash?: string }> = (props) => {
             >
               <div
                 class={
-                  'w-[85vw] overflow-auto z-20 p-10 shadow-2xl border-2 bg-white dark:bg-solid-darkbg border-gray-100 ' +
+                  'w-[85vw] overflow-auto p-10 shadow-2xl border-2 bg-white dark:bg-solid-darkbg border-gray-100 ' +
                   'dark:bg-solid-darkLighterBg fixed left-0 top-14 lg:bg-transparent lg:translate-x-0 lg:duration-0 transition-transform ' +
                   'duration-300 max-w-md lg:w-auto lg:border-0 lg:shadow-none lg:p-0 lg:flex-col lg:top-12 ' +
                   'relative lg:flex z-50'


### PR DESCRIPTION
Previously `filter`ed example code covered up side menu.

![image](https://user-images.githubusercontent.com/2218736/153481038-d22cec9f-d00c-471b-9c80-7b1127302c5b.png)
