### PR TITLE
Add `text-black` to input, fixes dark mode issue

### DIFF
--- a/src/pages/Tutorial.tsx
+++ b/src/pages/Tutorial.tsx
@@ -117,7 +117,7 @@ const DirectoryMenu: Component<DirectoryMenuProps> = (props) => {
               name="search"
               type="search"
               placeholder="Search..."
-              class="py-2 px-3 block w-full"
+              class="py-2 px-3 block w-full text-black"
             />
           </li>
           <For each={filteredDirectory()}>
@@ -231,7 +231,7 @@ const Tutorial: Component = () => {
                   rehypePlugins={[rehypeHighlight]}
                   components={{
                     pre: ({ children, node, ...props }) => (
-                      <div className="not-prose">
+                      <div class="not-prose">
                         <pre {...props}>{children}</pre>
                       </div>
                     ),


### PR DESCRIPTION
- Add `text-black` to search input to fix input text not being visible in dark mode
- Use `class` instead of `className`

Screenshot (with text in the input field):
<img width="317" alt="image" src="https://user-images.githubusercontent.com/9019273/157553145-04f48e58-3f06-4980-ab03-897c467f90c8.png">
