### PR TITLE
Remove border from benchmarks

### DIFF
--- a/src/components/Benchmarks.tsx
+++ b/src/components/Benchmarks.tsx
@@ -57,7 +57,7 @@ const Chart: Component<{ rows: Array<RowData>; scale: string; direction: string 
                     >
                       {row.score ? (
                         <figure>
-                          <span class="inline-block p-1 ltr:border-l rtl:border-r border-white px-2 rounded-full">
+                          <span class="inline-block p-1 px-2 rounded-full">
                             {row.score.toLocaleString()}
                           </span>
                         </figure>


### PR DESCRIPTION
Border looked out of place, especially in dark mode.

 Before:
<img width="621" alt="Screen Shot 2022-03-23 at 7 35 39 pm" src="https://user-images.githubusercontent.com/1286001/159657862-b99e5b2a-7e2a-45af-a920-012d25f0719f.png">
<img width="631" alt="Screen Shot 2022-03-23 at 7 35 19 pm" src="https://user-images.githubusercontent.com/1286001/159657879-23f3bd46-289c-418b-b6a0-834eaf47766b.png">

After:
<img width="602" alt="Screen Shot 2022-03-23 at 7 35 46 pm" src="https://user-images.githubusercontent.com/1286001/159657905-880d25d0-df8c-46be-982b-df22babd7669.png">
<img width="631" alt="Screen Shot 2022-03-23 at 7 35 49 pm" src="https://user-images.githubusercontent.com/1286001/159657912-f716f075-eb4b-4303-a5be-983d124253ba.png">

