### PR TITLE
Fix/broken monaco reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "solid-js": "^1.3.13",
     "solid-markdown": "^1.1.0",
     "solid-meta": "^0.27.3",
-    "solid-repl": "^0.22.0",
+    "solid-repl": "^0.23.4",
     "solid-social": "^0.6.2",
     "solid-transition-group": "^0.0.8",
     "solid-utils": "^0.8.1"

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,4 +1,4 @@
-@import url('solid-repl/lib/style.css');
+@import url('solid-repl/lib/bundle.css');
 @import url('highlight.js/styles/github.css');
 
 @font-face {

--- a/yarn.lock
+++ b/yarn.lock
@@ -922,10 +922,10 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/standalone@^7.17.6":
-  version "7.17.7"
-  resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.17.7.tgz#293de21553c1dc4157f84f4043d3ea00bdf57430"
-  integrity sha512-461jrYyk7g4bRQoOROABqErtygmZrx1cZXWONIPCQzVTynT5VL83btu1PJIaXNgl4JtHXjzaYT7j3IOlVhnC1Q==
+"@babel/standalone@^7.17.8":
+  version "7.17.8"
+  resolved "https://registry.yarnpkg.com/@babel/standalone/-/standalone-7.17.8.tgz#517064e5b21015476d4dc9c6518b47bf2ec4d094"
+  integrity sha512-tr3SDpVnxR/fzrxyG+HZPAyEA9eTHZIAjy4eqrc7m+KBwsdo1YvTbUfJ6teWHQ177mk6GmdmltsIiOYCcvRPWA==
 
 "@babel/template@^7.16.7":
   version "7.16.7"
@@ -1188,13 +1188,6 @@
   integrity sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==
   dependencies:
     defer-to-connect "^2.0.1"
-
-"@tailwindcss/forms@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.5.0.tgz#d4bea2560a10aac642573e72d3b4d62a88960449"
-  integrity sha512-KzWugryEBFkmoaYcBE18rs6gthWCFHHO7cAZm2/hv3hwD67AzwP7udSCa22E7R1+CEJL/FfhYsJWrc0b1aeSzw==
-  dependencies:
-    mini-svg-data-uri "^1.2.3"
 
 "@tailwindcss/typography@^0.5.0":
   version "0.5.2"
@@ -1567,6 +1560,16 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
+babel-plugin-jsx-dom-expressions@^0.32.11:
+  version "0.32.11"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.32.11.tgz#089f062a2089a781d85c517962eb2d4788e58ea6"
+  integrity sha512-hytqY33SGW6B3obSLt8K5X510UwtNkTktCCWgwba+QOOV0CowDFiqeL+0ru895FLacFaYANHFTu1y76dg3GVtw==
+  dependencies:
+    "@babel/helper-module-imports" "7.16.0"
+    "@babel/plugin-syntax-jsx" "^7.16.5"
+    "@babel/types" "^7.16.0"
+    html-entities "2.3.2"
+
 babel-plugin-jsx-dom-expressions@^0.32.8:
   version "0.32.10"
   resolved "https://registry.yarnpkg.com/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.32.10.tgz#8d58b4944b69274769150494b2b788145525a4d2"
@@ -1601,7 +1604,14 @@ babel-plugin-polyfill-regenerator@^0.3.0:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.3.1"
 
-babel-preset-solid@1.3.12, babel-preset-solid@^1.3.0:
+babel-preset-solid@1.3.13:
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/babel-preset-solid/-/babel-preset-solid-1.3.13.tgz#312373712a0492ff9e561ecb7a97aa7079aa018b"
+  integrity sha512-MZnmsceI9yiHlwwFCSALTJhadk2eea/+2UP4ec4jkPZFR+XRKTLoIwRkrBh7uLtvHF+3lHGyUaXtZukOmmUwhA==
+  dependencies:
+    babel-plugin-jsx-dom-expressions "^0.32.11"
+
+babel-preset-solid@^1.3.0:
   version "1.3.12"
   resolved "https://registry.yarnpkg.com/babel-preset-solid/-/babel-preset-solid-1.3.12.tgz#221010a6ee6041c0d7926a196f2a730e75e9e56f"
   integrity sha512-2/ggNVrYoZ/XMGB5ap9G5qoCXfYxm6GJ9NDhPz3+G4f4kSNQ1CMqZbQAfuKpUqEmtvcOM2riIgNsgeAdUiiGMw==
@@ -4446,11 +4456,6 @@ mimic-response@^3.1.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
   integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
-mini-svg-data-uri@^1.2.3:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz#8ab0aabcdf8c29ad5693ca595af19dd2ead09939"
-  integrity sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==
-
 minimalistic-assert@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -5205,6 +5210,11 @@ prettier@^2.5.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.0.tgz#12f8f504c4d8ddb76475f441337542fa799207d4"
   integrity sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==
 
+prettier@^2.6.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.1.tgz#d472797e0d7461605c1609808e27b80c0f9cfe17"
+  integrity sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==
+
 pretty-bytes@^5.3.0, pretty-bytes@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
@@ -5403,11 +5413,6 @@ regexpu-core@^5.0.1:
     unicode-match-property-ecmascript "^2.0.0"
     unicode-match-property-value-ecmascript "^2.0.0"
 
-register-service-worker@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/register-service-worker/-/register-service-worker-1.7.2.tgz#6516983e1ef790a98c4225af1216bc80941a4bd2"
-  integrity sha512-CiD3ZSanZqcMPRhtfct5K9f7i3OLCcBBWsJjLh1gW9RO/nS94sVzY59iS+fgYBOBqaBpf4EzfqUF3j9IG+xo8A==
-
 regjsgen@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.6.0.tgz#83414c5354afd7d6627b16af5f10f41c4e71808d"
@@ -5568,7 +5573,7 @@ rollup-plugin-terser@^7.0.0:
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
 
-rollup@^2.43.1, rollup@^2.59.0, rollup@^2.60.2, rollup@^2.70.0:
+rollup@^2.43.1, rollup@^2.59.0, rollup@^2.60.2, rollup@^2.70.1:
   version "2.70.1"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.70.1.tgz#824b1f1f879ea396db30b0fc3ae8d2fead93523e"
   integrity sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==
@@ -5744,22 +5749,22 @@ solid-dismiss@^1.0.27:
   resolved "https://registry.yarnpkg.com/solid-dismiss/-/solid-dismiss-1.0.27.tgz#4e9720a81f7758edf0605a1ed2adc0c5ce33e068"
   integrity sha512-y9g7SeoiXADA2UwFtqpTr3m8BsQNEoQESHO/jpjHDZMSCN1T2cq0XmbsMEsih0YUbkdW3pwhyrfq55DUtKaSFg==
 
-solid-heroicons@^2.0.1, solid-heroicons@^2.0.3:
+solid-heroicons@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/solid-heroicons/-/solid-heroicons-2.0.3.tgz#f442413f0d1ff0b77e0c0bc275a2e1eb2afd1e53"
   integrity sha512-sHlEaCaFFD8s/RDWTlmfIC/5dUPOtRB/UqOTpXQLq/BUZ94jWS58CANwONBclxwKFFGu6iasaP5zN4iYqORlVg==
   dependencies:
     solid-js "^1.3.10"
 
-solid-js@1.3.12, solid-js@^1.3.0, solid-js@^1.3.10, solid-js@^1.3.3:
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/solid-js/-/solid-js-1.3.12.tgz#6a02d49e92d3544aa4be6173a5cd974206b808f0"
-  integrity sha512-JnIoF5f40WR8LTEU1McFz/xVnXT3bGyBIme7gFbGj2ch6wXg+vcfbbhc2mz6YaLJIt8NEU+wAg8v+6SX3ZP9mA==
-
-solid-js@^1.3.13:
+solid-js@1.3.13, solid-js@^1.3.13:
   version "1.3.13"
   resolved "https://registry.yarnpkg.com/solid-js/-/solid-js-1.3.13.tgz#7e1a0f52e5b22b4c21ac2ac5196dfd2176ee3a46"
   integrity sha512-1EBEIW9u2yqT5QNjFdvz/tMAoKsDdaRA2Jbgykd2Dt13Ia0D4mV+BFvPkOaseSyu7DsMKS23+ZZofV8BVKmpuQ==
+
+solid-js@^1.3.0, solid-js@^1.3.10, solid-js@^1.3.3:
+  version "1.3.12"
+  resolved "https://registry.yarnpkg.com/solid-js/-/solid-js-1.3.12.tgz#6a02d49e92d3544aa4be6173a5cd974206b808f0"
+  integrity sha512-JnIoF5f40WR8LTEU1McFz/xVnXT3bGyBIme7gFbGj2ch6wXg+vcfbbhc2mz6YaLJIt8NEU+wAg8v+6SX3ZP9mA==
 
 solid-markdown@^1.1.0:
   version "1.1.0"
@@ -5799,28 +5804,26 @@ solid-refresh@^0.4.0:
     "@babel/helper-module-imports" "^7.16.0"
     "@babel/types" "^7.16.0"
 
-solid-repl@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/solid-repl/-/solid-repl-0.22.0.tgz#700f928e77f89ac63c18fe5729641ccc19ddb752"
-  integrity sha512-BcXKOP5MaJuvozR6wYm4i0ZYobBVaPRKRCepqsM5skxJDx1y6iJQCLkfezG15U/wzCd0zN5UfOvhZO5twwBAig==
+solid-repl@^0.23.4:
+  version "0.23.4"
+  resolved "https://registry.yarnpkg.com/solid-repl/-/solid-repl-0.23.4.tgz#470e6298ac2a769b311789aed8f9978fc6c2bb0a"
+  integrity sha512-XIH2NOkRrN85AlKnB0t7Ka7FgNbpJ1MG869NwOwhTDpgWJEyBG0veGbEXciQoCiqhuEPdXy6VJUsUgINtK9wmA==
   dependencies:
     "@amoutonbrady/lz-string" "^0.0.1"
     "@babel/preset-typescript" "^7.16.7"
-    "@babel/standalone" "^7.17.6"
-    "@tailwindcss/forms" "^0.5.0"
-    babel-preset-solid "1.3.12"
+    "@babel/standalone" "^7.17.8"
+    babel-preset-solid "1.3.13"
     dedent "^0.7.0"
     jszip "^3.7.1"
     mitt "^3.0.0"
     monaco-editor-textmate "^3.0.0"
     monaco-textmate "^3.0.1"
     onigasm "^2.2.5"
-    prettier "^2.5.1"
-    register-service-worker "^1.7.2"
-    rollup "^2.70.0"
+    prettier "^2.6.0"
+    rollup "^2.70.1"
     solid-dismiss "^1.0.27"
-    solid-heroicons "^2.0.1"
-    solid-js "1.3.12"
+    solid-heroicons "^2.0.3"
+    solid-js "1.3.13"
 
 solid-social@^0.6.2:
   version "0.6.2"


### PR DESCRIPTION
Fixed a weird bug where Monaco would reload the models despite them not being fully disposed and cause some sort of crash.

@modderme123 If you want to check it out, this was the original attempt: https://github.com/solidjs/solid-playground/commit/93dca08422803dbc70fa16ddad3d12838d3117a8

and this was the final one: https://github.com/solidjs/solid-playground/commit/d810833aee152740adaa9032d1a4c7166a600aff

Also, I had some build issue I had to work around which renamed the CSS file from `solid-repl`... no big deal but just in case you wonder why I updated it.

edit: the discussion first erupted on discord: https://discord.com/channels/722131463138705510/730114401427783713/956650868684517436