### PR TITLE
Fix  Resources search field

### DIFF
--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -21,6 +21,7 @@ import { createCountdown } from '@solid-primitives/date';
 import { createIntersectionObserver } from '@solid-primitives/intersection-observer';
 import Dismiss from 'solid-dismiss';
 import { useRouteReadyState } from '../utils/routeReadyState';
+import { parseKeyword } from '../utils/parseKeyword';
 
 export enum ResourceType {
   Article = 'article',
@@ -147,7 +148,7 @@ const Resources: Component = () => {
     keys: ['author', 'title', 'categories', 'keywords', 'link', 'description'],
     threshold: 0.3,
   });
-  const [keyword, setKeyword] = createSignal(globalThis.location.hash.replace('#', ''));
+  const [keyword, setKeyword] = createSignal(parseKeyword(globalThis.location.hash));
   const [filtered, setFiltered] = createStore({
     // Produces a base set of filtered results
     resources: createMemo(() => {

--- a/src/utils/parseKeyword.ts
+++ b/src/utils/parseKeyword.ts
@@ -1,0 +1,4 @@
+const blacklistedCharacters = /[^a-z\s]+/gi;
+export const parseKeyword = (hash: string): string => {
+  return decodeURIComponent(hash).replace(blacklistedCharacters, ' ').trim();
+}


### PR DESCRIPTION
If user browses Docs and then opens Resources page, search field is filled with encoded string, e.g. `location.hash === '#<suspense>'`. This fix cleans up `location.hash` and sets proper value to search field.

### Before

![image](https://user-images.githubusercontent.com/2003850/160474805-dc32feb9-24e8-4d34-af9b-aab013d05523.png)

### After

![image](https://user-images.githubusercontent.com/2003850/160474943-b6578142-b0d0-4552-b5c3-53d0a16f5f3d.png)
