### PR TITLE
Add solid-icons library on resources json

### DIFF
--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -138,6 +138,17 @@ const utilities: Array<Resource> = [
     categories: [ResourceCategory.AddOn, ResourceCategory.UI],
   },
   {
+    link: 'https://github.com/x64Bits/solid-icons',
+    title: 'solid-icons',
+    description: 'The simplest way to use icons in SolidJS',
+    author: 'Ignacio Zsabo',
+    author_url: 'https://github.com/x64Bits',
+    keywords: ['icons', 'svg', 'iconpack'],
+    official: false,
+    type: ResourceType.Package,
+    categories: [ResourceCategory.AddOn, ResourceCategory.UI],
+  },
+  {
     link: 'https://github.com/amoutonbrady/esbuild-plugin-solid',
     title: 'esbuild-plugin-solid',
     description: 'Plugin to compile solid-js jsx components with esbuild.',


### PR DESCRIPTION
The [solid-icons](https://github.com/x64Bits/solid-icons) library has been added to the resources page.

