### PR TITLE
Fix Resources icons deformations on smaller widths

### DIFF
--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -84,7 +84,7 @@ const Resource: Component<Resource> = (props) => {
         rel="nofollow"
       >
         <div class="col-span-2 md:col-span-3 lg:col-span-1 flex items-center justify-center">
-          <figure class="flex justify-center content-center w-11 h-11 md:w-14 md:h-14 p-1.5 border-4 border-solid-medium dark:border-solid-darkdefault rounded-full text-white">
+          <figure class="flex justify-center content-center w-11 h-11 md:w-14 md:h-14 p-1.5 border-4 border-solid-medium dark:border-solid-darkdefault rounded-full text-white flex-shrink-0">
             <Icon
               class="text-solid-medium dark:text-solid-darkdefault w-5/6"
               path={ResourceTypeIcons[props.type]}
@@ -264,7 +264,7 @@ const Resources: Component = () => {
                     class="grid grid-cols-5 lg:grid-cols-6 items-center w-full text-sm py-3 text-left border rounded-md dark:border-solid-darkLighterBg"
                   >
                     <div class="col-span-1 lg:col-span-2 flex justify-center px-2">
-                      <figure class="flex justify-center content-center w-10 h-10 p-1.5 border-4 border-solid rounded-full text-white">
+                      <figure class="flex justify-center content-center w-10 h-10 p-1.5 border-4 border-solid rounded-full text-white flex-shrink-0">
                         <Icon
                           class="text-solid-medium dark:text-solid-darkdefault w-5/6"
                           path={ResourceTypeIcons[type]}


### PR DESCRIPTION
Resources icons were deformed on smaller widths (< 1280px and <1024px). Added `flex-shrink-0` classes on icons `<figure />` elements to fix these issues.

### Before

![Screen Shot 2022-05-04 at 00 03 41](https://user-images.githubusercontent.com/2003850/166566022-1701f28e-d93e-4d40-96bb-1d3d101e7ecf.png)

![Screen Shot 2022-05-04 at 00 06 25](https://user-images.githubusercontent.com/2003850/166566328-42d64a49-058e-4cfd-bc5e-5e93fd22cedc.png)

### After

![Screen Shot 2022-05-04 at 00 03 46](https://user-images.githubusercontent.com/2003850/166566026-07969f32-538c-46cd-bfde-6d1747124116.png)

![Screen Shot 2022-05-04 at 00 06 28](https://user-images.githubusercontent.com/2003850/166566331-7295af4e-c833-4257-b727-266663de70df.png)

