### PR TITLE
docs: Fix published_at to be ms format; Fix author typo

### DIFF
--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -1200,13 +1200,13 @@ const utilities: Array<Resource> = [
     link: 'https://github.com/jaoaustero/solid-tawk-messenger',
     title: 'Tawk.to Messenger',
     description: 'Tawk messenger chat for SolidJS',
-    author: 'Jao AUstero',
+    author: 'Jao Austero',
     author_url: 'https://github.com/jaoaustero',
     keywords: ['tawk', 'tawkto', 'live-chat', 'chat-plugin', 'chat-widget', 'kb', 'knowledge-base', 'message'],
     official: false,
     type: ResourceType.Package,
     categories: [ResourceCategory.Plugins, ResourceCategory.AddOn],
-    published_at: 1651083453,
+    published_at: 1651083453000,
   },
 ];
 


### PR DESCRIPTION
### Fix
* Wrong date rendered it shows **Jan 20 1970** it should be **Apr 27, 2022**
* Format date was on seconds and changed it to milli-seconds
* Fix typo on authors name

![image](https://user-images.githubusercontent.com/15128024/166716872-3ee16a59-2400-4744-926d-223e4fb7bb8e.png)
