### PR TITLE
Fix ecosystem path for italian language

### DIFF
--- a/lang/it/global.json
+++ b/lang/it/global.json
@@ -6,7 +6,7 @@
     { "title": "Iniziare", "path": "/guides" },
     { "title": "Esercitazione", "path": "/tutorial" },
     { "title": "API", "path": "/docs/latest/api" },
-    { "title": "Ecosistema", "path": "/ecoststem" },
+    { "title": "Ecosistema", "path": "/ecosystem" },
     { "title": "Esempi", "path": "/examples" },
     { "title": "Playground", "path": "https://playground.solidjs.com", "external": true },
     { "title": "Blog", "path": "/blog" },


### PR DESCRIPTION
Currently, navigating with the italian language, the ecosystem nav link redirects to the 404 page

Also, is it wanted that the 404 title page uses a "bad-word"? It seemed strange to me. One of the most common label for 404 is "Ops. Pagina non trovata"
![image](https://user-images.githubusercontent.com/37072694/168975942-b8a46f0d-2c2c-4c09-a319-a2d6ef45b9b3.png)