### PR TITLE
Added lang attr to html element, fixing a11y issue (WCAG 2.1 3.1.1)

### DIFF
--- a/src/AppContext.tsx
+++ b/src/AppContext.tsx
@@ -92,6 +92,9 @@ export const AppContextProvider: ParentComponent = (props) => {
     if (!lang.loading) add(i18n[1].locale(), lang() as Record<string, any>);
   });
   createEffect(() => {
+    document.documentElement.lang = locale();
+  });
+  createEffect(() => {
     if (isDark()) document.documentElement.classList.add('dark');
     else document.documentElement.classList.remove('dark');
   });


### PR DESCRIPTION
Happy Accessibility Awareness Day!

When I opened the landing page the first thing I noticed was that the screen reader is reading out english text in my default system voice(german), to fix this I added the lang attribute to the root html element.

https://www.w3.org/TR/WCAG21/#language-of-page