### PR TITLE
Fixed Italian Language Typos and Inconsistencies 1

### DIFF
--- a/lang/it/contributors.json
+++ b/lang/it/contributors.json
@@ -6,7 +6,7 @@
   "copy": "Solid non sarebbe possibile senza l'aiuto di altre persone di talento. Man mano che cresciamo, speriamo che altri trovino il modo di dedicare il loro tempo sotto forma di segnalazione di bug, pull request, suggerimenti di progettazione, scrittura e molti altri modi.",
   "translators_copy": "Le seguenti persone hanno gentilmente dedicato il loro tempo e i loro sforzi per garantire che Solid diventi internazionale:",
   "ecosystem_team": "Gruppo di ecosistema",
-  "contributors": "Contributrici",
+  "contributors": "Contributori",
   "open_collective": "Open Collective",
   "support_copy": "Sostienici con una donazione e aiutaci a continuare le nostre attività:"
 }

--- a/lang/it/global.json
+++ b/lang/it/global.json
@@ -21,14 +21,14 @@
     "email": "Indirizzo email",
     "success": "Ti sei registrato con successo!",
     "error": "Impossibile completare la registrazione",
-    "register": "Registrare",
+    "register": "Registrati",
     "sending": "Invio..."
   },
   "footer": {
     "declaration": "Solid è un progetto open source supportato da un team di contributori pubblici. È distribuito <a class=\"underline hover:text-gray-500\" href=\"{{license}}\">con licenza MIT</a>. Questa libreria e comunità sono rese possibili da un <a class=\"underline hover:text-gray-500\" href=\"{{contributors}}\">team principale e collaboratori dedicati</a>.",
     "license": "https://github.com/solidjs/solid/blob/master/LICENSE",
     "contributors": "/contributors",
-    "sponsored_by": "Sponsorizzata da",
+    "sponsored_by": "Sponsorizzati da",
     "updated": "Ultimo aggiornamento {{date}} su Solid v{{version}}"
   }
 }

--- a/lang/it/home.json
+++ b/lang/it/home.json
@@ -1,118 +1,115 @@
 {
-    "hero": "Una libreria JavaScript dichiarativa, efficiente e flessibile per la creazione di interfacce utente.",
-    "get_started": "Iniziare",
-    "intro_video": "Introduzione a Solid (100 secondi)",
-    "intro_video_advanced": "Introduzione avanzata (100 minuti)",
-    "ukraine": {
-      "support": "Siamo con l'Ucraina.",
-      "petition": "Aiutaci a fornire aiuti umanitari.",
-      "link": "https://www.stopputin.net/"
+  "hero": "Una libreria JavaScript dichiarativa, efficiente e flessibile per la creazione di interfacce utente.",
+  "get_started": "Iniziare",
+  "intro_video": "Introduzione a Solid (100 secondi)",
+  "intro_video_advanced": "Introduzione avanzata (10 minuti)",
+  "ukraine": {
+    "support": "Siamo con l'Ucraina.",
+    "petition": "Aiutaci a fornire aiuti umanitari.",
+    "link": "https://www.stopputin.net/"
+  },
+  "info": "Solid è una libreria puramente reattiva. È stato progettato da zero con un nucleo reattivo. È influenzato da principi reattivi sviluppati da precedenti librerie.",
+  "strengths": [
+    {
+      "icon": "performant",
+      "label": "Efficiente",
+      "description": "Esegue estremamente bene su tutti i test di prestazione riconosciuti."
     },
-    "info": "Solid è una libreria puramente reattiva. È stato progettato da zero con un nucleo reattivo. È influenzato da principi reattivi sviluppati da precedenti librerie.",
-    "strengths": [
-      {
-        "icon": "performant",
-        "label": "Efficiente",
-        "description": "Esegue estremamente bene su tutti i test di prestazione riconosciuti."
-      },
-      {
-        "icon": "powerful",
-        "label": "Potente",
-        "description": "Primitive reattive componibili sposate con la flessibilità di JSX."
-      },
-      {
-        "icon": "pragmatic",
-        "label": "Pragmatico",
-        "description": "Un'API sensata e su misura per lo sviluppo in modo semplice ed efficiente."
-      },
-      {
-        "icon": "productive",
-        "label": "Produttivo",
-        "description": "Ergonomia e familiarità intorno alla costruzione semplice e complessa."
-      }
+    {
+      "icon": "powerful",
+      "label": "Potente",
+      "description": "Primitive reattive componibili sposate con la flessibilità di JSX."
+    },
+    {
+      "icon": "pragmatic",
+      "label": "Pragmatico",
+      "description": "Un'API sensata e su misura per lo sviluppo in modo semplice ed efficiente."
+    },
+    {
+      "icon": "productive",
+      "label": "Produttivo",
+      "description": "Ergonomia e familiarità intorno alla costruzione semplice e complessa."
+    }
+  ],
+  "facts": [
+    {
+      "label": "6.4kb",
+      "detail": "Minified + Gzipped",
+      "link": "https://bundlephobia.com/package/solid-js@1.2.1"
+    },
+    {
+      "label": "15k+",
+      "detail": "Stelle Github",
+      "link": "https://star-history.t9t.io/#solidjs/solid"
+    },
+    {
+      "label": "5+ years",
+      "detail": "In sviluppo"
+    },
+    {
+      "label": "TypeScript",
+      "detail": "Supporto"
+    },
+    {
+      "label": "Top Rated",
+      "detail": "Per le prestazioni"
+    },
+    {
+      "label": "Astro",
+      "detail": "Supporto",
+      "link": "https://github.com/snowpackjs/astro/tree/main/examples/framework-solid"
+    }
+  ],
+  "example": {
+    "headline": "È familiare e moderno",
+    "copy": [
+      "Solid sta sulle spalle dei giganti, in particolare React e Knockout. Se hai già sviluppato con React Hooks, Solid dovrebbe sembrare molto naturale. In effetti, più naturale in quanto il modello di Solid è molto più semplice senza regole Hook. Ogni componente viene eseguito una volta e sono gli hook e le associazioni che vengono eseguiti molte volte man mano che le loro dipendenze si aggiornano.",
+      "Solid segue la stessa filosofia di React con flusso di dati unidirezionale, segregazione di lettura/scrittura e interfacce immutabili. Ha un'implementazione completamente diversa che rinuncia all'utilizzo di un DOM virtuale."
     ],
-    "facts": [
-      {
-        "label": "6.4kb",
-        "detail": "Minified + Gzipped",
-        "link": "https://bundlephobia.com/package/solid-js@1.2.1"
-      },
-      {
-        "label": "15k+",
-        "detail": "Stelle Github",
-        "link": "https://star-history.t9t.io/#solidjs/solid"
-      },
-      {
-        "label": "5+ years",
-        "detail": "In sviluppo"
-      },
-      {
-        "label": "TypeScript",
-        "detail": "Supporto"
-      },
-      {
-        "label": "Top Rated",
-        "detail": "Per le prestazioni"
-      },
-      {
-        "label": "Astro",
-        "detail": "Supporto",
-        "link": "https://github.com/snowpackjs/astro/tree/main/examples/framework-solid"
-      }
-    ],
-    "example": {
-      "headline": "È familiare e moderno",
-      "copy": [
-        "Solid sta sulle spalle dei giganti, in particolare React e Knockout. Se hai già sviluppato con React Hooks, Solid dovrebbe sembrare molto naturale. In effetti, più naturale in quanto il modello di Solid è molto più semplice senza regole Hook. Ogni componente viene eseguito una volta e sono gli hook e le associazioni che vengono eseguiti molte volte man mano che le loro dipendenze si aggiornano.",
-        "Solid segue la stessa filosofia di React con flusso di dati unidirezionale, segregazione di lettura/scrittura e interfacce immutabili. Ha un'implementazione completamente diversa che rinuncia all'utilizzo di un DOM virtuale."
-      ],
-      "link_label": "Visualizza la documentazione",
-      "link": "https://www.solidjs.com/docs/latest#component-apis"
+    "link_label": "Visualizza la documentazione",
+    "link": "https://www.solidjs.com/docs/latest#component-apis"
+  },
+  "reactivity": {
+    "headline": "Reattività a grana fine significa fare di più con meno.",
+    "subheadline": "Solid è costruito con primitive reattive efficienti dal codice della tua area utente alle tue JSX.",
+    "copy": "Questo sblocca il controllo completo su cosa viene aggiornato e quando/Anche a livello di associazione DOM. Senza Virtual DOM o diffing esteso, il framework non funziona mai più di quanto tu voglia.",
+    "link_label": "Guardalo in azione",
+    "link": "https://playground.solidjs.com/?version=1.0.0#NobwRAdghgtgpmAXGGUCWEwBowBcCeADgsrgM4Ae2YZA9gK4BOAxiWGjIbY7gAQi9GcCABM4jXgF9eAM0a0YvAOR0ANmhEBaAFZkA9AHc4AIyUBuADoQOXHv17MhUXHADKaAObRVU2fMUqtOpauuZWVjL0EMy4aLQQvACChIQAFACU-Fa8DvFkfMBQMWgAbnBYvGRwuInFZQC6vAC8Dk4u7l5Qqqm4jPRw6ZYQ2YLVTAkAPCKlDqpQZGRNIEWxZRm8APy8FmArpXA7vIjbYDuSAHwAEmgTetMl51aS4RBCouKp603nvBPJhLw9OcKiJaMx6PAILgAHQeaoAUVUcEhuAAQvgAJIiVJKKApJTpdJWMCSepAA"
+  },
+  "performance": {
+    "headline": ["Incentrato sulle prestazioni", "sia su client che su server"],
+    "copy": "La forza della reattività a grana fine come approccio brilla su tutti i benchmark importanti. Le prestazioni potrebbero non essere il tuo obiettivo, ma l'esperienza dell'utente finale dovrebbe sempre essere una priorità. Pensa al miglioramento delle prestazioni di Solid come a una vittoria gratuita senza ulteriore complessità di sviluppo. Si tratta di essere veloci senza provare.",
+    "link_label": "Leggi l'articolo completo",
+    "link": "https://ryansolid.medium.com/solidjs-the-tesla-of-javascript-ui-frameworks-6a1d379bc05e"
+  },
+  "features": {
+    "headline": "Completamente caricato con tutte le funzionalità.",
+    "copy": "Solid supporta tutte le funzionalità di libreria comuni e previste. Si espande sugli aspetti per aumentare l'esperienza dello sviluppatore.",
+    "list": [
+      "Fragments",
+      "Portals",
+      "Context",
+      "Suspense",
+      "Error Boundaries",
+      "Lazy Components",
+      "Async & Concurrent Rendering",
+      "Implicit Delegation",
+      "SSR & Hydration",
+      "Directives",
+      "Streaming"
+    ]
+  },
+  "benchmarks": {
+    "time": "Volta",
+    "link_label": "Il JS Framework Benchmark confronta le prestazioni del browser in un'ampia gamma di test. È meglio più basso.",
+    "show_more": "Mostra più benchmark client + server",
+    "js_benchmark": {
+      "title": "JS Framework Benchmark",
+      "description": "Il JS Framework Benchmark confronta le prestazioni del browser in un'ampia gamma di test. È meglio più basso."
     },
-    "reactivity": {
-      "headline": "Reattività a grana fine significa fare di più con meno.",
-      "subheadline": "Solid è costruito con primitive reattive efficienti dal codice della tua area utente alle tue JSX.",
-      "copy": "Questo sblocca il controllo completo su cosa viene aggiornato e quando/Anche a livello di associazione DOM. Senza Virtual DOM o diffing esteso, il framework non funziona mai più di quanto tu voglia.",
-      "link_label": "Guardalo in azione",
-      "link": "https://playground.solidjs.com/?version=1.0.0#NobwRAdghgtgpmAXGGUCWEwBowBcCeADgsrgM4Ae2YZA9gK4BOAxiWGjIbY7gAQi9GcCABM4jXgF9eAM0a0YvAOR0ANmhEBaAFZkA9AHc4AIyUBuADoQOXHv17MhUXHADKaAObRVU2fMUqtOpauuZWVjL0EMy4aLQQvACChIQAFACU-Fa8DvFkfMBQMWgAbnBYvGRwuInFZQC6vAC8Dk4u7l5Qqqm4jPRw6ZYQ2YLVTAkAPCKlDqpQZGRNIEWxZRm8APy8FmArpXA7vIjbYDuSAHwAEmgTetMl51aS4RBCouKp603nvBPJhLw9OcKiJaMx6PAILgAHQeaoAUVUcEhuAAQvgAJIiVJKKApJTpdJWMCSepAA"
-    },
-    "performance": {
-      "headline": [
-        "Incentrato sulle prestazioni",
-        "sia su client che su server"
-      ],
-      "copy": "La forza della reattività a grana fine come approccio brilla su tutti i benchmark importanti. Le prestazioni potrebbero non essere il tuo obiettivo, ma l'esperienza dell'utente finale dovrebbe sempre essere una priorità. Pensa al miglioramento delle prestazioni di Solid come a una vittoria gratuita senza ulteriore complessità di sviluppo. Si tratta di essere veloci senza provare.",
-      "link_label": "Leggi l'articolo completo",
-      "link": "https://ryansolid.medium.com/solidjs-the-tesla-of-javascript-ui-frameworks-6a1d379bc05e"
-    },
-    "features": {
-      "headline": "Completamente caricato con tutte le funzionalità.",
-      "copy": "Solid supporta tutte le funzionalità di libreria comuni e previste. Si espande sugli aspetti per aumentare l'esperienza dello sviluppatore.",
-      "list": [
-        "Fragments",
-        "Portals",
-        "Context",
-        "Suspense",
-        "Error Boundaries",
-        "Lazy Components",
-        "Async & Concurrent Rendering",
-        "Implicit Delegation",
-        "SSR & Hydration",
-        "Directives",
-        "Streaming"
-      ]
-    },
-    "benchmarks": {
-      "time": "Volta",
-      "link_label": "Il JS Framework Benchmark confronta le prestazioni del browser in un'ampia gamma di test. È meglio più basso.",
-      "show_more": "Mostra più benchmark client + server",
-      "js_benchmark": {
-        "title": "JS Framework Benchmark",
-        "description": "Il JS Framework Benchmark confronta le prestazioni del browser in un'ampia gamma di test. È meglio più basso."
-      },
-      "isomorophic_benchmark": {
-        "title": "Isomorphic UI Benchmarks (Search Results)",
-        "description": "Questo benchmark testa le velocità di rendering del server non elaborato. Più alto è meglio."
-      }
+    "isomorophic_benchmark": {
+      "title": "Isomorphic UI Benchmarks (Search Results)",
+      "description": "Questo benchmark testa le velocità di rendering del server non elaborato. Più alto è meglio."
     }
   }
+}


### PR DESCRIPTION
Fixed some of the Typos.

"Contributrici" means female contributors.
Corrected to "Contributori"  since it refers to a collective.

"Sponsorizzata da",  is using the female version of the word. 
The correct word for this situation is "Sponsorizzati da".

"Registrati" in this case works better.

There was a typo in the Advanced Introduction. It is supposed to be 10 minutes, not 100 minutes.



