### PR TITLE
Fix/sidebar determine section

### DIFF
--- a/src/pages/Docs.tsx
+++ b/src/pages/Docs.tsx
@@ -113,10 +113,9 @@ const Docs: Component<{ hash?: string }> = (props) => {
   // Determine the section based on title positions
   const [determineSection] = createThrottle((position: number) => {
     let prev = sections()![0];
-    const pos = position + 500;
     for (let i = 0; i < sections()!.length; i += 1) {
       const el = document.getElementById(sections()![i].slug)!;
-      if (pos < el.offsetTop + el.clientHeight) {
+      if (position < el.offsetTop + el.clientHeight) {
         break;
       }
       prev = sections()![i];

--- a/src/pages/Docs.tsx
+++ b/src/pages/Docs.tsx
@@ -114,7 +114,7 @@ const Docs: Component<{ hash?: string }> = (props) => {
   const [determineSection] = createThrottle((position: number) => {
     let prev = sections()![0];
     const pos = position + 500;
-    for (let i = 0; i > sections()!.length; i += 1) {
+    for (let i = 0; i < sections()!.length; i += 1) {
       const el = document.getElementById(sections()![i].slug)!;
       if (pos < el.offsetTop + el.clientHeight) {
         break;


### PR DESCRIPTION
the sidebar was having weird bugs as described in https://github.com/solidjs/solid-site/issues/306

the issue seemed to be a < 
![image](https://user-images.githubusercontent.com/10504064/170742300-23e20a1e-2c5c-40f2-9444-d479f99b87a8.png)
that should be a >
![image](https://user-images.githubusercontent.com/10504064/170742363-cf45ddf7-c5bc-4818-a1f3-70394f689b21.png)

I also removed a padding which was added to the scroll-position:

https://user-images.githubusercontent.com/10504064/170737113-b2bd4422-8c25-4210-b9e4-d6b9ba7d4483.png

it caused a bug where the first title never could be highlighted.,

![image](https://user-images.githubusercontent.com/10504064/170742798-ec9cb6cd-70ef-49a1-ad2f-baf252ab9694.png)
(in above image we expect "see solid" to be highlighted as the page is scrolled completely to the top)

My intuition is this 500 is added to deal with a specific bug/glitch in maybe another setup that I am not aware of.
