### PR TITLE
feat: add `solid-hcaptcha` to utilities list

### DIFF
--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -1527,6 +1527,17 @@ const utilities: Array<Resource> = [
     categories: [ResourceCategory.UI],
     published_at: 1652052027000,
   },
+  {
+    link: 'https://github.com/Vexcited/solid-hcaptcha',
+    title: 'solid-hcaptcha',
+    description: 'hCaptcha Component Library for Solid.',
+    author: 'Mikkel Ringaud',
+    author_url: 'https://github.com/Vexcited',
+    keywords: ['hcaptcha', 'captcha'],
+    official: false,
+    type: PackageType.Package,
+    categories: [ResourceCategory.Plugins],
+  },
 ];
 
 export default utilities;


### PR DESCRIPTION
Hello, this PR adds `solid-hcaptcha` to utilities list.
It is a port of [@hcaptcha/react-hcaptcha](https://github.com/hCaptcha/react-hcaptcha) for [Solid](https://www.solidjs.com/).

Please let me know if you want me to make any changes.