### PR TITLE
Vertical align homepage facts

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -86,7 +86,7 @@ const Home: Component<{}> = () => {
                 const d = (
                   <>
                     <strong class="font-semibold mr-1">{fact.label}</strong>
-                    <span class="block text-sm">{fact.detail}</span>
+                    <span class="flex items-center text-sm">{fact.detail}</span>
                   </>
                 );
                 return (


### PR DESCRIPTION
When the facts section is collapsed on `sm` sizes, the `fact.label` and `fact.detail` are not vertically aligned:

![align_1](https://user-images.githubusercontent.com/13180538/173209279-8d68794c-0912-425f-83a4-2fd46d221329.png)

Adding a `flex align-center` to so the elements are vertically aligned: 

![align_2](https://user-images.githubusercontent.com/13180538/173209363-6b3874a2-eb7e-4875-aa3e-2f35fa075ed5.png)

