### PR TITLE
a11y: Reduce duplication in nav logo alt text

### DIFF
--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -135,12 +135,11 @@ const Nav: ParentComponent<{ showLogo?: boolean; filled?: boolean }> = (props) =
               ref={logoEl}
             >
               <Link href="/" onClick={onClickLogo} noScroll class={`py-3 flex w-9 `}>
-                <span class="sr-only">Navigate to the home page</span>
-                <img class="w-full h-auto z-10" src={logo} alt="Solid logo" />
+                <img class="w-full h-auto z-10" src={logo} alt="SolidJS" />
                 <img
                   class={`w-8 h-5 absolute ${isRTL() ? 'mr-5 -scale-x-100 mt-2' : 'ml-5 mt-3'}`}
                   src={ukraine}
-                  alt="Solid logo"
+                  alt=""
                 />
               </Link>
             </div>

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -134,7 +134,13 @@ const Nav: ParentComponent<{ showLogo?: boolean; filled?: boolean }> = (props) =
               }`}
               ref={logoEl}
             >
-              <Link href="/" onClick={onClickLogo} noScroll class={`py-3 flex w-9 `}>
+              <Link
+                href="/"
+                onClick={onClickLogo}
+                noScroll
+                class={`py-3 flex w-9`}
+                aria-describedby="ukraine-support"
+              >
                 <img class="w-full h-auto z-10" src={logo} alt="SolidJS" />
                 <img
                   class={`w-8 h-5 absolute ${isRTL() ? 'mr-5 -scale-x-100 mt-2' : 'ml-5 mt-3'}`}
@@ -142,6 +148,7 @@ const Nav: ParentComponent<{ showLogo?: boolean; filled?: boolean }> = (props) =
                   alt=""
                 />
               </Link>
+			  <span id="ukraine-support" hidden>{t('home.ukraine.support', {}, 'We stand with Ukraine.')}</span>
             </div>
             <ScrollShadow
               class="group relative nav-items-container"


### PR DESCRIPTION
Currently, when a screenreader user navigates to the logo link in the docs' navbar, their screenreader will announce `link, Navigate to the home page Solid logo Solid logo`. This is because the link has some hidden text that says "Navigate to the homepage," followed by two images that both have the alt text of "Solid logo." This is makes the screenreader experience pretty cluttered. Additionally, [voice control users](https://www.smashingmagazine.com/2022/06/voice-control-usability-considerations-partially-visually-hidden-link-names/) will have a tough time guessing at this full name to be able to target the link successfully. This pull request reduces the complexity of the logo link contents and alt text so that the link only announces `link, SolidJS`. This keeps the experience terse, and more easily guessable for voice control users.

The logo also currently displays a graphic of support for Ukraine, which I believe is also important to convey. To convey this without providing clutter or messing with the voice control experience, I've wired up a node to serve as the element's _accessible description,_ which the link points to using `aria-describedby`. [I've written more about that](https://benmyers.dev/blog/aria-labels-and-descriptions/) if you're interested in learning more. The effect of having a description is that it'll be exposed as supplemental information if a screenreader user lingers on the logo link, but it won't clutter terser modes of screenreader navigation, and it won't impact voice control users' ability to target the link. I've set this node's contents to be the `home.ukraine.support` localized string ("We stand with Ukraine" in the English translation).

## Related Links

- [Guidance from W3C's Web Accessibility Initiative for providing alt text for functional images](https://www.w3.org/WAI/tutorials/images/functional/)
- [WebAIM's guidance on alt text for functional images](https://webaim.org/techniques/alttext/#functional)