### PR TITLE
Fixing "Solid Store" title

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -171,7 +171,7 @@ const Header: ParentComponent<{ title?: string }> = () => {
                           <Title>{t('resources.title', {}, 'Ecosystem')}</Title>
                         </Match>
                         <Match when={location.pathname.includes('/store')}>
-                          <Title>{t('store.title', {}, 'Store Store')}</Title>
+                          <Title>{t('store.title', {}, 'Solid Store')}</Title>
                         </Match>
                         <Match when={location.pathname.includes('/examples')}>
                           <Title>{t('examples.title', {}, 'Examples')}</Title>


### PR DESCRIPTION
Should the header of the page say "Store Store"?

![image](https://user-images.githubusercontent.com/33182225/179032415-9b62f46f-193a-41a5-9125-62cfc127eb30.png)
