### PR TITLE
fix: explicit color-scheme for embedded tweets

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -171,6 +171,10 @@ pre {
   color-scheme: dark;
 }
 
+.twitter-solid-social > .twitter-tweet {
+  color-scheme: normal;
+}
+
 /* START TOOLTIP STYLES */
 @media (hover: hover) {
   [data-tooltip] {


### PR DESCRIPTION
- color-scheme: dark breaks tweet borders, set it to normal for those