### PR TITLE
read solid version from package.json

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,11 +12,6 @@ import vercel from '../assets/supporters/vercel.webp';
 import stytch from '../assets/supporters/stytch.webp';
 import Social from './Social';
 
-declare global {
-  const __UPDATED_AT__: string;
-  const __SOLID_VERSION__: string;
-}
-
 const Supporter: Component<{
   img: string;
   alt: string;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+declare const __UPDATED_AT__: string;
+declare const __SOLID_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,13 @@
-import { defineConfig, PluginOption } from 'vite';
+import { defineConfig } from 'vite';
 import solid from 'vite-plugin-solid';
 import mdx from '@mdx-js/rollup';
 import remarkGfm from 'remark-gfm';
+import { dependencies } from './package.json';
 
 export default defineConfig({
   define: {
     __UPDATED_AT__: JSON.stringify(new Date().toLocaleString()),
-    __SOLID_VERSION__: JSON.stringify('1.4.7'),
+    __SOLID_VERSION__: JSON.stringify(dependencies['solid-js']),
   },
   plugins: [
     {
@@ -17,7 +18,7 @@ export default defineConfig({
         remarkPlugins: [remarkGfm],
       }),
       enforce: 'pre',
-    } as PluginOption,
+    },
     solid({ extensions: ['.md', '.mdx'] }),
     // VitePWA(pwaOptions),
   ],


### PR DESCRIPTION
- avoid hardcoding solid version in vite config also
- moved globals definition to vite-env.d.ts and removed globals from
Footer
- minor vite.config.ts cleanup - conversion with as to PluginOption
was unneeded, removed it