### PR TITLE
[STYLING] Edit TailwindCSS config in order to fix link style

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -81,6 +81,7 @@ module.exports = {
             a: {
               color: '#999',
               textDecoration: 'none',
+              fontWeight: '600',
               '&:hover': {
                 color: '#2c4f7c',
               },


### PR DESCRIPTION
Just noticed a small CSS issue on links 
<img width="318" alt="Capture d’écran 2022-08-12 à 12 03 44" src="https://user-images.githubusercontent.com/32040951/184332401-4e79b62b-4221-438d-a49d-dc079f1e0979.png">
<img width="335" alt="Capture d’écran 2022-08-12 à 12 03 42" src="https://user-images.githubusercontent.com/32040951/184332416-c463d4ba-0fae-4b5e-98a7-b9c17d0a1058.png">