### PR TITLE
add solid-devtools to resources

### DIFF
--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -116,6 +116,17 @@ const utilities: Array<Resource> = [
     categories: [ResourceCategory.BuildUtilities],
   },
   {
+    link: 'https://github.com/thetarnav/solid-devtools',
+    title: 'Solid Developer Tools',
+    description: 'Library of developer tools, reactivity debugger & Devtools Chrome extension for visualizing SolidJS reactivity graph.',
+    author: 'Damian Tarnawski',
+    author_url: 'https://github.com/thetarnav/solid-devtools',
+    keywords: ['debug', 'devtools'],
+    official: false,
+    type: PackageType.Package,
+    categories: [ResourceCategory.BuildUtilities],
+  },
+  {
     link: 'https://github.com/solidjs/solid-playground',
     title: 'solid-playground',
     description: 'A playground and REPL for Solid.',


### PR DESCRIPTION
Adding my devtools because well why not :)

Not sure if I'm supposed to add it to the end or not... so I've added it next to a similar project: solid-debug.

Also, shouldn't the [amoutonbrady/solid-debug](https://github.com/amoutonbrady/solid-debug) project be removed from the list? It was important for the experimentation purposes, but it's now 2 years old, so I don't know if it's still actually usable for other people.