### PR TITLE
Add solid-flow to ecosystem packages

### DIFF
--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -1748,6 +1748,18 @@ const utilities: Array<Resource> = [
     type: PackageType.Package,
     categories: [ResourceCategory.Starters, ResourceCategory.BuildUtilities],
   },
+  {
+    link: 'https://github.com/miguelsalesvieira/solid-flow',
+    title: 'solid-flow',
+    description:
+      'A simple component for building interactive node-based diagrams and editors.',
+    author: 'Miguel Vieira',
+    author_url: 'https://github.com/miguelsalesvieira',
+    keywords: ['ui', 'drag', 'flow'],
+    official: false,
+    type: PackageType.Package,
+    categories: [ResourceCategory.UI],
+  },
 ];
 
 export default utilities;


### PR DESCRIPTION
I would like to contribute to the ecosystem by adding solid-flow, which is a simple component that allows developers to easily build interactive node-based diagrams and editors with solidjs. You can check the [documentation](https://miguel-vieira.gitbook.io/solid-flow/) on the [repo](https://github.com/miguelsalesvieira/solid-flow) for more information as well as a live [demo](https://solidflowdemo.netlify.app/).