### PR TITLE
Fix podcast embeds

### DIFF
--- a/src/pages/Articles/state-of-solid-september-2021.mdx
+++ b/src/pages/Articles/state-of-solid-september-2021.mdx
@@ -110,11 +110,13 @@ Despite the translation, you can get the humor of this article which provides so
 
 [SolidJS with Ryan Carniato](https://podrocket.logrocket.com/solidjs) - PodRocket
 We talk about a lot more than just Solid but trends in frontend in general.
-<ListenNotesEpisode episodeId="podrocket-a-web/solidjs-with-ryan-carniato-GhrWpzbKU4I" height="140px"/>
+
+<iframe src="https://player.fireside.fm/v2/XHXVzqW5+v7N9UeJk?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
 
 [React vs Svelte vs Solid & MicroFrontends | Ryan Carniato](https://show.nikoskatsikanis.com/episodes/ryan-carniato) - Nikos Show
 This podcast talks about developments in compilers and in server-side rendering in JavaScript Frameworks.
-<ListenNotesEpisode episodeId="the-nikos-show/react-vs-svelte-vs-solid-1BC3sm92rUR" height="140px"/>
+
+<iframe height="200px" width="100%" frameborder="no" scrolling="no" seamless src="https://player.simplecast.com/a5c919cd-a681-4715-a4f8-0682cd8641cd?dark=true"></iframe>
 
 ### Videos
 


### PR DESCRIPTION
Specifically https://www.solidjs.com/blog/state-of-solid-september-2021  
  
The `<ListenNotesEpisode>` component doesn't exist, so causes the blog post to fail to load.