### PR TITLE
fix: fixed blog podcast links for September 2021

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "solid-js": "1.6.6",
     "solid-meta": "^0.28.1",
     "solid-repl": "^0.24.0",
-    "solid-social": "^0.9.1",
+    "solid-social": "^0.9.6",
     "solid-transition-group": "^0.0.10",
     "solid-utils": "^0.8.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ specifiers:
   solid-mdx: ^0.0.6
   solid-meta: ^0.28.1
   solid-repl: ^0.24.0
-  solid-social: ^0.9.1
+  solid-social: ^0.9.6
   solid-transition-group: ^0.0.10
   solid-utils: ^0.8.1
   svgo: ^2.8.0
@@ -87,11 +87,11 @@ dependencies:
   shopify-buy: 2.17.1
   solid-app-router: 0.4.2_solid-js@1.5.1
   solid-dismiss: 1.4.1_solid-js@1.5.1
-  solid-heroicons: 2.0.3_solid-js@1.5.1
+  solid-heroicons: 2.0.3
   solid-js: 1.5.1
   solid-meta: 0.28.1_solid-js@1.5.1
   solid-repl: 0.24.0_monaco-editor@0.33.0
-  solid-social: 0.9.5_solid-js@1.5.1
+  solid-social: 0.9.6_solid-js@1.5.1
   solid-transition-group: 0.0.10_solid-js@1.5.1
   solid-utils: 0.8.1_solid-js@1.5.1
 
@@ -118,7 +118,7 @@ devDependencies:
   prettier: 2.8.1
   solid-mdx: 0.0.6_solid-js@1.5.1+vite@4.0.3
   svgo: 2.8.0
-  tailwindcss: 3.2.4_postcss@8.4.20
+  tailwindcss: 3.2.4
   tailwindcss-dir: 4.0.0
   tailwindcss-rtl: 0.9.0
   terser-config-atomic: 0.1.1
@@ -2007,7 +2007,7 @@ packages:
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.2.4_postcss@8.4.20
+      tailwindcss: 3.2.4
     dev: true
 
   /@trysound/sax/0.2.0:
@@ -5987,10 +5987,8 @@ packages:
       solid-js: 1.5.1
     dev: false
 
-  /solid-heroicons/2.0.3_solid-js@1.5.1:
+  /solid-heroicons/2.0.3:
     resolution: {integrity: sha512-sHlEaCaFFD8s/RDWTlmfIC/5dUPOtRB/UqOTpXQLq/BUZ94jWS58CANwONBclxwKFFGu6iasaP5zN4iYqORlVg==}
-    peerDependencies:
-      solid-js: '>= ^1.2.5'
     dependencies:
       solid-js: 1.5.1
     dev: false
@@ -6055,7 +6053,7 @@ packages:
       prettier: 2.8.1
       rollup: 2.79.1
       solid-dismiss: 1.4.1_solid-js@1.5.1
-      solid-heroicons: 2.0.3_solid-js@1.5.1
+      solid-heroicons: 2.0.3
       solid-js: 1.5.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -6063,8 +6061,8 @@ packages:
       - supports-color
     dev: false
 
-  /solid-social/0.9.5_solid-js@1.5.1:
-    resolution: {integrity: sha512-L8u2BEmuV8zxf9qxc0II6kj1BJhbreEclSbsKrhM62q+f2J3kEnBURKVWaIF3xu3cfGInCqbRVKcGwcC+fVnJA==}
+  /solid-social/0.9.6_solid-js@1.5.1:
+    resolution: {integrity: sha512-3ZEu5dQR/8kqI7jpCbxErr0SBxTwIWQBbNgab8gNv9mNRWabQ0e2pGT32wpnWUnt50HoSx+hVIRpo/ZY94uxWw==}
     peerDependencies:
       solid-js: ^1.3.0
     dependencies:
@@ -6360,12 +6358,10 @@ packages:
       resolve: 1.22.1
     dev: true
 
-  /tailwindcss/3.2.4_postcss@8.4.20:
+  /tailwindcss/3.2.4:
     resolution: {integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==}
     engines: {node: '>=12.13.0'}
     hasBin: true
-    peerDependencies:
-      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3

--- a/src/pages/Articles/state-of-solid-december-2021.mdx
+++ b/src/pages/Articles/state-of-solid-december-2021.mdx
@@ -17,7 +17,7 @@ While there’s plenty of excitement, the biggest battle we face is showing why 
 
 Solid has also been on a few other streams and podcasts recently:
 
-<Spotify spotifyLink="episode/2acyt1NRqjXMnX4LZqDyTV" width="100%" height={352} />
+<Spotify spotifyLink="episode/2acyt1NRqjXMnX4LZqDyTV" />
 <br />
 
 <YouTube youTubeId="PRDtEyC5X1U" />

--- a/src/pages/Articles/state-of-solid-september-2021.mdx
+++ b/src/pages/Articles/state-of-solid-september-2021.mdx
@@ -110,11 +110,11 @@ Despite the translation, you can get the humor of this article which provides so
 
 [SolidJS with Ryan Carniato](https://podrocket.logrocket.com/solidjs) - PodRocket
 We talk about a lot more than just Solid but trends in frontend in general.
-<ListenNotesEpisode episodeId="podrocket-a-web/solidjs-with-ryan-carniato-GhrWpzbKU4I" height="140px"/>
+<Spotify spotifyLink="episode/40RDz6zayJYk7QM8kQxaBK" />
 
 [React vs Svelte vs Solid & MicroFrontends | Ryan Carniato](https://show.nikoskatsikanis.com/episodes/ryan-carniato) - Nikos Show
 This podcast talks about developments in compilers and in server-side rendering in JavaScript Frameworks.
-<ListenNotesEpisode episodeId="the-nikos-show/react-vs-svelte-vs-solid-1BC3sm92rUR" height="140px"/>
+<Spotify spotifyLink="episode/1d9XabKMHflqFLGuMT0bLh" />
 
 ### Videos
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -68,9 +68,7 @@ const Home: Component = () => {
           class="flex items-center space-x-3 justify-center text-center text-solid-medium dark:bg-solid-light/40 dark:text-white m-5 md:mx-0 hover:text-solid-dark transition duration-500 bg-slate-200/50 max-width-[300px] rounded-lg p-5 text-lg"
         >
           <Icon class="w-10" stroke-width={1.5} path={shoppingCart} />
-          <div
-          innerHTML={t('home.news.content')}
-          />
+          <div innerHTML={t('home.news.content')} />
         </a>
         <section class="grid sm:grid-cols-2 lg:grid-cols-4 space-y-4 lg:space-y-0 lg:space-x-4 rounded-lg">
           <For each={t('home.strengths')}>

--- a/src/pages/Resources/Articles.data.ts
+++ b/src/pages/Resources/Articles.data.ts
@@ -1123,7 +1123,7 @@ const articles: Array<Resource> = [
   {
     link: 'https://blog.knappi.org/0018-solid-js/',
     title: 'Solid.js, the best of Vue and React',
-    description: "",
+    description: '',
     author: 'Nils Knappmeier ',
     author_url: 'https://blog.knappi.org/',
     keywords: ['solid', 'react', 'vue'],

--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -1952,14 +1952,15 @@ const utilities: Array<Resource> = [
   {
     link: 'https://kobalte.dev/',
     title: 'kobalte',
-    description: "A library of unstyled components for building accessible web apps and design systems with SolidJS.",
+    description:
+      'A library of unstyled components for building accessible web apps and design systems with SolidJS.',
     author: 'Fabien Marie-Louise',
     author_url: 'https://github.com/fabien-ml',
     keywords: ['kobalte', 'headless', 'unstyled', 'aria', 'components'],
     official: false,
     type: PackageType.Package,
     categories: [ResourceCategory.UI],
-    published_at: 1672867714000
+    published_at: 1672867714000,
   },
   {
     title: '@klass/solid',
@@ -1972,7 +1973,7 @@ const utilities: Array<Resource> = [
     official: false,
     keywords: ['class', 'css', 'styled', ''],
     published_at: 1672135531594,
-  }
+  },
 ];
 
 export default utilities;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import solid from 'vite-plugin-solid';
 import mdx from '@mdx-js/rollup';
 import rehypeHighlight from 'rehype-highlight';
 import remarkGfm from 'remark-gfm';
-import * as pckg from './package.json';
+import pckg from './package.json' assert { type: 'json' };
 
 export default defineConfig({
   define: {


### PR DESCRIPTION
- updated podcasts links from ListenNotes to Spotify for September 2021
- updated solid-social to 0.9.6 (removes the need to define width and height for Spotify component)
- updated package import for vite.config.ts and restore type assert
- formatting with Prettier