### PR TITLE
Add @cookbook/solid-intl to Ecosytem Packages and fix missing single quote in string

### DIFF
--- a/src/pages/Resources/Articles.data.ts
+++ b/src/pages/Resources/Articles.data.ts
@@ -1135,7 +1135,7 @@ const articles: Array<Resource> = [
     link: 'https://dev.to/omher/intro-to-solidjs-how-to-create-fast-reactive-web-apps-15cn',
     title: 'Intro to SolidJS: How to Create Fast, Reactive Web Apps',
     description: '',
-    author: 'Omher,
+    author: 'Omher',
     author_url: 'https://dev.to/omher',
     keywords: ['solid', 'react', 'intro'],
     type: ResourceType.Article,

--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -1960,8 +1960,21 @@ const utilities: Array<Resource> = [
     type: PackageType.Library,
     categories: [ResourceCategory.UI, ResourceCategory.Primitives],
     official: false,
-    keywords: ['class', 'css', 'styled', ''],
+    keywords: ['class', 'css', 'styled'],
     published_at: 1672135531594,
+  },
+  {
+    title: '@cookbook/solid-intl',
+    link: 'https://github.com/the-cookbook/solid-intl',
+    author: 'Marcos Gonçalves',
+    author_url: 'https://github.com/themgoncalves',
+    description:
+      'A universal internationalization (i18n) for Solid inspired by React Intl & FormatJS.',
+    type: PackageType.Library,
+    categories: [ResourceCategory.UI, ResourceCategory.Data, ResourceCategory.Plugins],
+    official: false,
+    keywords: ['i18n', 'internation', 'l10n', 'localization', 'translation', 'ssr'],
+    published_at: 1672790400000,
   },
 ];
 


### PR DESCRIPTION
Hello,

As discussed on Discord, this PR adds our [@cookbook/solid-intl](https://github.com/the-cookbook/solid-intl) package to site's Ecosystem Packages page.

I also encountered a small issue regarding a missing `'` which I'm also pushing a fix.