### PR TITLE
Increase bottom padding on doc's sidebar

### DIFF
--- a/src/pages/Docs.tsx
+++ b/src/pages/Docs.tsx
@@ -36,7 +36,7 @@ const Sidebar: Component<{
   current: Accessor<string | null>;
   hash: string | undefined;
 }> = (props) => (
-  <ul class="lg:pl-10 overflow-auto pt-10 flex dark:text-white flex-col flex-1">
+  <ul class="lg:pl-10 overflow-auto py-10 flex dark:text-white flex-col flex-1">
     <For each={props.items}>
       {(firstLevel: Section) => (
         <SectionButton


### PR DESCRIPTION
A browser default link preview/tooltip shows on the bottom left of the viewport whenever the user has their cursor over a link.

Issue:
When user engaged in scrolling on left sidebar/table of contents, inevitably users will hover on links during scroll and raise the browser tooltip. 
Upon scrolling to the end, without bottom padding of the sidebar, browser's tooltip actually blocks the last item to be viewed.  
This impedes the fluidity of quickly glancing over/scrolling over all the items.

Solution:
This tiny change adds the bottom padding which gives enough spacing so the tooltip no longer obstruct the listed items when user scrolls to the end. Additionally it adds a sense of balance with appropriate spacing with the edge of the window.