### PR TITLE
Added dark mode background to select dropdown

### DIFF
--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -55,7 +55,7 @@ const Product: Component<{ details: ShopifyProduct; cart: CartUtilities }> = (pr
       <div class="flex justify-center rounded-b border-t divide-white dark:border-solid-gray">
         <Show when={props.details.variants.length > 1}>
           <select
-            class="py-4 pl-4 text-xs w-4/6 rounded-bl-lg bg-transparent"
+            class="py-4 pl-4 text-xs w-4/6 rounded-bl-lg bg-transparent dark:bg-solid-darkbg"
             onChange={(evt) => setCurrent(evt.currentTarget.value)}
           >
             <For each={props.details.variants}>


### PR DESCRIPTION
Hello,
I've opened this PR fixing #439 which refers to the Store page where the `<select>` tag is being used.

I've read about the website being redeveloped so I don't know if this PR would be useful, but meanwhile it will improve readability of product options while in dark mode 😀 
