### PR TITLE
Allowed cart item removal from product card

### DIFF
--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -21,6 +21,14 @@ const Product: Component<{ details: ShopifyProduct; cart: CartUtilities }> = (pr
     return null;
   });
   const quantity = props.cart.variantQuantity(current);
+  const remove = async () => {
+    setLoading(true);
+    const itemToRemove = props.cart.cart.lines.find((line) => line.variant.id == current());
+    if (itemToRemove) {
+      await props.cart.remove([itemToRemove.id.toString()]);
+    }
+    setLoading(false);
+  };
   const adjustQuantity = (quantity = 1) => {
     setLoading(true);
     props.cart
@@ -67,7 +75,7 @@ const Product: Component<{ details: ShopifyProduct; cart: CartUtilities }> = (pr
           <button
             title="Remove item"
             disabled={loading() || quantity() == 0}
-            onClick={() => adjustQuantity(-1)}
+            onClick={() => (quantity() == 1 ? void remove() : adjustQuantity(-1))}
             class="transition text-solid-light hover:opacity-60 disabled:hidden disabled:text-solid-light font-semibold text-lg rounded-full w-25 h-25"
             classList={{
               'opacity-80': loading(),


### PR DESCRIPTION
Hello,
I've opened this PR to fix an issue in Store page where I couldn't remove from the cart any product using the remove button located into the Product Card.

So, along the lines of how the Cart component works, I've added a remove function to invoke when item quantity is 1. The function checks which LineItem has to be removed from the cart, making its `id` match with what it's stored into the `current()` Signal.

I don't know much about Shopify API so maybe there's a better way to pass the correct id to the `remove` API, but what it's stored into the Signal wasn't recognized as valid.

Thank you for your attention 😄 