### PR TITLE
feat: add solid-dzone and solid-marquee to ecosystem's packages list

### DIFF
--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -2162,6 +2162,18 @@ const utilities: Array<Resource> = [
     keywords: ['dropzone', 'drag', 'drag and drop', 'solid', 'solidjs'],
     published_at: 1677371956000,
   },
+  {
+    title: 'solid-marquee',
+    link: 'https://github.com/Jcanotorr06/solid-marquee',
+    author: 'Jcanotorr06',
+    author_url: 'https://github.com/Jcanotorr06',
+    description: 'A simple and lightweight Marquee component for SolidJS.',
+    type: PackageType.Package,
+    categories: [ResourceCategory.UI],
+    official: false,
+    keywords: ['marquee', 'solid', 'solidjs'],
+    published_at: 1677504886000,
+  },
 ];
 
 export default utilities;

--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -2150,6 +2150,18 @@ const utilities: Array<Resource> = [
     keywords: ['wundergraph', 'data', 'tanstack', 'graph'],
     published_at: 1677094221000,
   },
+  {
+    title: 'solid-dzone',
+    link: 'https://github.com/Jcanotorr06/solid-dzone',
+    author: 'Jcanotorr06',
+    author_url: 'https://github.com/Jcanotorr06',
+    description: 'A simple and easy to use Dropzone primitive for SolidJS.',
+    type: PackageType.Package,
+    categories: [ResourceCategory.UI, ResourceCategory.Primitives],
+    official: false,
+    keywords: ['dropzone', 'drag', 'drag and drop', 'solid', 'solidjs'],
+    published_at: 1677371956000,
+  },
 ];
 
 export default utilities;


### PR DESCRIPTION
## Included Packages

- [`solid-dzone`](https://www.npmjs.com/package/solid-dzone): a simple high quality dropzone primitive inspired by react-dropzone for solid.
- [ `solid-marquee`](https://www.npmjs.com/package/solid-marquee): a lightweight marquee component that utilizes the power of CSS animations to create silky smooth marquees.