### PR TITLE
fix: missing spanish text

### DIFF
--- a/lang/es/global.json
+++ b/lang/es/global.json
@@ -38,10 +38,10 @@
       "path": "/contributors",
       "links": [
         {
-          "title": "SolidHack",
-          "description": "Conoce nuestro hackathon 2022.",
-          "path": "https://hack.solidjs.com",
-          "external": true
+          "title": "Tienda",
+          "description": "Camisetas de la marca, stickers etc.",
+          "path": "/store",
+          "external": false
         },
         {
           "title": "Blog",
@@ -57,6 +57,18 @@
           "title": "Media",
           "description": "Material de la marca",
           "path": "/media"
+        },
+        {
+          "title": "SolidHack",
+          "description": "Conoce nuestro hackathon 2022.",
+          "path": "https://hack.solidjs.com",
+          "external": true
+        },
+        {
+          "title": "Codigo de Conducta",
+          "description": "Nuestras reglas de comunidad y contribución.",
+          "path": "https://github.com/solidjs/solid/blob/main/CODE_OF_CONDUCT.md",
+          "external": true
         },
         {
           "title": "OpenCollective",

--- a/lang/es/home.json
+++ b/lang/es/home.json
@@ -3,6 +3,9 @@
   "get_started": "Empieza Ahora",
   "intro_video": "Introducción a SolidJS (100 segundos)",
   "intro_video_advanced": "Introducción avanzada (10 minutos)",
+  "news": {
+    "content": "Visita la nueva <b>Tienda Solid</b> para stickers, camisetas y más!"
+  },
   "strengths": [
     {
       "icon": "performant",


### PR DESCRIPTION
I noticed the Spanish Site was missing from some Text while I tried to buy some merch from Solid, so this is a fix to add missing text around the Store and also the order of the Menu where it resides.