### PR TITLE
remove attempt to prevent default on a passive listener

### DIFF
--- a/src/components/ScrollShadow/ScrollShadow.tsx
+++ b/src/components/ScrollShadow/ScrollShadow.tsx
@@ -30,8 +30,6 @@ const ScrollShadow: ParentComponent<
   const scrollHorizontally = (e: WheelEvent) => {
     if (!isScrollable) return;
 
-    e.preventDefault();
-
     const target = e.currentTarget as HTMLElement;
     target.scrollLeft += e.deltaX + e.deltaY;
   };


### PR DESCRIPTION
Fixes these console errors
<img width="1493" alt="image" src="https://github.com/solidjs/solid-site/assets/3259993/c50a4381-59bb-467e-9297-dd8a923d985d">

It looks like the call was added in c07e5b39428e33594fc4e7435350d6b3de6f1592 and `passive` was removed at that point,

but then it was broken when `passive` came back in db61119132e1c8bda27cdb04bd1466e09810eb63.

So not sure if this is the correct fix, of if the fix should be removing `passive` again?