### PR TITLE
chore: uncomment markDownRef.scrollTop

### DIFF
--- a/src/pages/Tutorial.tsx
+++ b/src/pages/Tutorial.tsx
@@ -170,7 +170,7 @@ const Tutorial: Component = () => {
   useRouteReadyState();
 
   createEffect(() => {
-    // markDownRef.scrollTop = 0;
+    markDownRef.scrollTop = 0;
     replEditor && replEditor.setScrollPosition({ scrollTop: 0 });
     const fileset = data.solved ? data.solvedJs : data.js;
     const files = fileset?.files;


### PR DESCRIPTION
## Overview

It doesn't scroll up to the top when you click the prev/next chapter on the turtorials page.
Changed it to scroll to the top every time a user clicks the prev/next chapter.

Side node:

Not exactly sure why the code was commented. Feel free to close the PR if this is the expected  behavior.
Also open to discuss better solutions for this.

### Current Behavior 
https://github.com/solidjs/solid-site/assets/32632542/0b0e7a8d-84da-4874-b560-e34c47a1e87e


###  Fixed Behavior

https://github.com/solidjs/solid-site/assets/32632542/4dac5bfb-6af8-4f4c-aa65-84d815c3bc97



