### PR TITLE
bump pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,5 +89,5 @@
   "resolutions": {
     "solid-js": "1.5.1"
   },
-  "packageManager": "pnpm@7.9.0"
+  "packageManager": "pnpm@8.6.2"
 }


### PR DESCRIPTION
We're pinned at an outdated pnpm version that sometimes has trouble resolving npm modules, this should fix that