### PR TITLE
add solidjs-paystack and solidjs-flutterwave library

### DIFF
--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -2304,6 +2304,18 @@ const utilities: Array<Resource> = [
     keywords: ['component', 'paystack', 'payment'],
     published_at: 1688908056276,
   },
+  {
+    title: 'solidjs-flutterwave',
+    link: 'https://github.com/rnwonder/solidjs-flutterwave',
+    author: 'Matthew Ruona',
+    author_url: 'https://github.com/rnwonder',
+    description: 'Flutterwave payment gateway for SolidJS.',
+    type: PackageType.Library,
+    categories: [ResourceCategory.Primitives, ResourceCategory.UI],
+    official: false,
+    keywords: ['component', 'flutterwave', 'payment'],
+    published_at: 1688926787929,
+  },
 ];
 
 export default utilities;

--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -2292,6 +2292,18 @@ const utilities: Array<Resource> = [
     keywords: ['map', 'maplibre', 'maplibre-gl-js', 'gis'],
     published_at: 1667602800000,
   },
+  {
+    title: 'solidjs-paystack',
+    link: 'https://github.com/rnwonder/solidjs-paystack',
+    author: 'Matthew Ruona',
+    author_url: 'https://github.com/rnwonder',
+    description: 'Paystack payment gateway for SolidJS.',
+    type: PackageType.Library,
+    categories: [ResourceCategory.Primitives, ResourceCategory.UI],
+    official: false,
+    keywords: ['component', 'paystack', 'payment'],
+    published_at: 1688908056276,
+  },
 ];
 
 export default utilities;


### PR DESCRIPTION
Payment gateway sdk integration for [Paystack](https://paystack.com/) and [Flutterwave](https://flutterwave.com/)

[Solid paystack Github Repo](https://github.com/rnwonder/solidjs-paystack)
[Solid flutterwave Github Repo](https://github.com/rnwonder/solidjs-flutterwave)