### PR TITLE
Add solid-monaco to the ecosystem

### DIFF
--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -2351,6 +2351,17 @@ const utilities: Array<Resource> = [
     categories: [ResourceCategory.Data, ResourceCategory.Primitives],
     keywords: ['swr', 'fetch', 'request', 'cache'],
   },
+  {
+    title: 'solid-monaco',
+    link: 'https://github.com/alxnddr/solid-monaco',
+    description: 'Monaco editor for Solid',
+    author: 'Aleksandr Lesnenko',
+    author_url: 'https://github.com/alxnddr',
+    keywords: ['monaco', 'editor', 'code editor', 'ui'],
+    official: false,
+    type: PackageType.Package,
+    categories: [ResourceCategory.Plugins, ResourceCategory.UI],
+  },
 ];
 
 export default utilities;


### PR DESCRIPTION
This PR adds [solid-monaco](https://github.com/alxnddr/solid-monaco) package to the ecosystem page. The `solid-monaco` provides a convenient component wrapper for embedding Monaco editor to Solid applications