### PR TITLE
Flip isomorphic bench for consistency

### DIFF
--- a/src/components/Benchmarks.tsx
+++ b/src/components/Benchmarks.tsx
@@ -17,11 +17,27 @@ interface RowData {
   score: number;
 }
 
-const Chart: Component<{ rows: RowData[]; scale: string; direction: string }> = (props) => {
+type SortMode = 'off' | 'asc' |'desc';
+
+const Chart: Component<{
+  rows: RowData[];
+  scale: string;
+  direction: string;
+  sort: SortMode;
+}> = (props) => {
   const maxValue = createMemo(() => Math.max(...props.rows.map((row) => row.score)));
+
+  const sortFn = (sortMode: SortMode) => {
+    switch (sortMode) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      case 'off': return (_a: RowData, _b: RowData)=> 0;
+      case 'asc': return (a:RowData, b:RowData) => a.score - b.score;
+      case 'desc': return (a:RowData, b:RowData) => b.score - a.score;
+    }
+  };
   const options = createMemo(() =>
     props.rows
-      .sort((a, b) => a.score - b.score)
+      .sort(sortFn(props.sort))
       .map((row) => ({
         ...row,
         width: `${(row.score / maxValue()) * 100}%`,
@@ -101,6 +117,7 @@ const Benchmarks: Component<{ list: Array<GraphData> }> = (props) => {
   return (
     <>
       <Chart
+        sort={props.list[current()].id == 'js-framework-benchmark' ? 'asc' : 'desc' }
         scale={props.list[current()].scale}
         rows={props.list[current()].data}
         direction={direction()}


### PR DESCRIPTION
It's better to have both benchmarks have the best scores in the top, instead of having them in reverse

<img width="567" alt="Screenshot 2023-10-09 at 20 32 59" src="https://github.com/solidjs/solid-site/assets/74932975/3be2ede6-f539-43db-9d76-5be2f69f0310">

<img width="548" alt="Screenshot 2023-10-09 at 20 34 09" src="https://github.com/solidjs/solid-site/assets/74932975/50eb70e9-fe84-4ed8-b20c-d4b50499a29f">
