### PR TITLE
Add ParaglideJS to Resources

### DIFF
--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -907,6 +907,18 @@ const utilities: Array<Resource> = [
     published_at: 1635523744000,
   },
   {
+    link: "https://inlang.com/c/solid",
+    title: "ParaglideJS",
+    description: "An ultra-efficient i18n library that scales to zero. Comes with first class integration with SolidStart",
+    author: "Inlang",
+    author_url: "https://inlang.com",
+    keywords: ["i18n", "localisation", "localization", "translate", "translations", "language", "intl"],
+    official: false,
+    type: PackageType.Package,
+    categories: [ResourceCategory.Plugins, ResourceCategory.UI,  ResourceCategory.Data],
+    published_at: 1702989010000,
+  },
+  {
     link: 'https://github.com/SanichKotikov/solid-i18n',
     title: 'solid-i18n',
     description: 'Tiny translation library for solid-js inspired by Rosetta.',


### PR DESCRIPTION
This PR adds [ParaglideJS](https://inlang.com/c/solid) to the ecosystem resources.

ParaglideJS is a i18n library that produces absolutely tiny bundles. It compiles all messages into treeshakeable JS code, which can then be split up per-page. ParaglideJS is fully useable with Solid & SolidStart.

At Inlang, we've been working on a first-class SolidStart integration for Paraglide that makes it a breeze to turn any SolidStart app into a multi-language app. It provides i18n routing and manages the language state. 
You can find it at `@inlang/paraglide-js-adapter-solidstart`. It's currently still in prerelease mode, but we plan on having a stable version in a couple weeks. 

I'm linking to the "Solid" category on Inlang.com instead of the ParaglideJS page so that we don't need separate entries for ParaglideJS core and the SolidStart adapter. I can change that if you want. 