### PR TITLE
Correct sticky tooltip background color

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -47,7 +47,9 @@ module.exports = {
           accent: '#0cdc73',
           secondaccent: '#0dfc85',
         },
-        amber: '#b45309',
+        amber: {
+          DEFAULT: '#b45309',
+        },
         'amber-light': '#f59e0b',
       },
       typography: ({ theme }) => ({


### PR DESCRIPTION
Due to a misconfiguration in tailwind's config, the CSS for the background color of this tooltip in the documentation was not generated correctly.
<img width="1066" alt="image" src="https://github.com/solidjs/solid-site/assets/48022591/cec678f1-7753-4661-8357-674fb7ef03b0">

Here is the result after the fix.
<img width="826" alt="image" src="https://github.com/solidjs/solid-site/assets/48022591/c33ebfa7-50a8-443a-af85-43cc0648f214">
