### PR TITLE
fix: update misspelled knockout

### DIFF
--- a/lang/pt/home.json
+++ b/lang/pt/home.json
@@ -56,7 +56,7 @@
     "example": {
       "headline": "É familiar e moderno",
       "copy": [
-        "Solid é pensado em cima de gigantes, principalmente React e Knocout. Se você já programou com os Hooks do React antes, Solid deve ser nada menos do que natural. Na verdade, até mais natural já que os modelos do Solid não usam as regras de hooks. Todo componente é executado apenas uma vez e seus hooks e ligações executam a cada atualização de dependência.",
+        "Solid é pensado em cima de gigantes, principalmente React e Knockout. Se você já programou com os Hooks do React antes, Solid deve ser nada menos do que natural. Na verdade, até mais natural já que os modelos do Solid não usam as regras de hooks. Todo componente é executado apenas uma vez e seus hooks e ligações executam a cada atualização de dependência.",
         "Solid segue a mesma filosofia do React com um fluxo unidirecional de dados, segregação de leitura e escrita e interfaces imutáveis. Apenas tem uma implementação completamente diferente que dispensa o uso de uma DOM virtual."
       ],
       "link_label": "Ver documentação",


### PR DESCRIPTION
Fixing misspelled text on pt home. :sparkles:

The wrong text is highlighted in the print bellow
<img width="676" alt="Screenshot 2024-03-14 at 10 47 33" src="https://github.com/solidjs/solid-site/assets/23343834/3eab3e79-3943-43a6-ac4d-e78d2626f6ba">
