### PR TITLE
fix: prevent text overlap

### DIFF
--- a/src/components/layout/SideContent.tsx
+++ b/src/components/layout/SideContent.tsx
@@ -55,7 +55,7 @@ const SideContent: Component<{
         <div class="w-full lg:w-9/12 p-5 md:p-10 bg-white dark:bg-solid-darkbg">
           <a
             href="https://docs.solidjs.com"
-            class="sticky top-16 p-3 w-full block text-white text-center rounded-md bg-amber-400 hover:bg-gray-400 transition duration-300"
+            class="sticky top-16 p-3 w-full block text-transparent hover:text-white text-center rounded-md bg-amber-400 hover:bg-gray-400 transition duration-300"
           >
             <b>New Beta Docs!</b>&nbsp;Click here to access new beta documentation at{' '}
             <u>docs.solidjs.com</u>.


### PR DESCRIPTION
To improve readability and avoid overlapping with other elements, set the text color to transparent by default and white on hover. See the second line of text in the image.
![image](https://github.com/solidjs/solid-site/assets/65339558/e972632e-6628-45d7-9b21-793bcd4bae57)
