### PR TITLE
update ref to solid-headless after rebranding to terracotta

### DIFF
--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -685,8 +685,8 @@ const utilities: Array<Resource> = [
     categories: [ResourceCategory.BuildUtilities, ResourceCategory.Plugins],
   },
   {
-    link: 'https://github.com/LXSMNSYC/solid-headless',
-    title: 'solid-headless',
+    link: 'https://github.com/lxsmnsyc/terracotta',
+    title: 'terracotta',
     description: 'Headless UI for SolidJS.',
     author: 'Alexis H. Munsayac',
     author_url: 'https://github.com/LXSMNSYC',


### PR DESCRIPTION
@lxsmnsyc has rebranded the library to **terracotta**, so this PR updates the ecosystem docs to reflect that.

see the old link https://github.com/LXSMNSYC/solid-headless, which now redirects to https://github.com/lxsmnsyc/terracotta.