### PR TITLE
docs: remove unnecessary category duplication for data viz libraries

### DIFF
--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -1727,7 +1727,7 @@ const utilities: Array<Resource> = [
     keywords: ['charts', 'apex', 'ui'],
     official: false,
     type: PackageType.Package,
-    categories: [ResourceCategory.AddOn, ResourceCategory.DataVisualization, ResourceCategory.UI],
+    categories: [ResourceCategory.DataVisualization],
   },
   {
     link: 'https://www.locatorjs.com/install/solidjs',
@@ -2333,7 +2333,7 @@ const utilities: Array<Resource> = [
     keywords: ['charts', 'chartjs', 'ui'],
     official: false,
     type: PackageType.Package,
-    categories: [ResourceCategory.AddOn, ResourceCategory.DataVisualization, ResourceCategory.UI],
+    categories: [ResourceCategory.DataVisualization],
   },
   {
     link: 'https://github.com/thedanchez/uplot-solid',
@@ -2344,7 +2344,7 @@ const utilities: Array<Resource> = [
     keywords: ['chart', 'plot', 'solid', 'ui', 'uplot'],
     official: false,
     type: PackageType.Package,
-    categories: [ResourceCategory.AddOn, ResourceCategory.DataVisualization, ResourceCategory.UI],
+    categories: [ResourceCategory.DataVisualization],
   },
   {
     title: '@rnwonder/solid-date-picker',
@@ -2474,7 +2474,7 @@ const utilities: Array<Resource> = [
     keywords: ['charts', 'echarts', 'data visualization', 'ui'],
     official: false,
     type: PackageType.Package,
-    categories: [ResourceCategory.AddOn, ResourceCategory.DataVisualization, ResourceCategory.UI],
+    categories: [ResourceCategory.DataVisualization],
   },
   {
     title: 'solid-keep-alive',


### PR DESCRIPTION
Just putting this PR up to remove the duplicate entries of these libraries across the different categories. After thinking about it for a bit, I came away with the thought that having all of this duplication across the categories just adds noise in the signal-to-noise ratio when searching for libraries. I feel that these things should be more targeted and granular perhaps?

Feel free to disagree and chuck (read close) this out. But just thought I'd put it up and spark the discussion. If there is agreement on the above premise, then this is something we can iteratively do on the rest of the libraries in the ecosystem list as time goes on.