### PR TITLE
docs: add @stitchapi/solid to Data resources

### DIFF
--- a/src/pages/Resources/Utilities.data.ts
+++ b/src/pages/Resources/Utilities.data.ts
@@ -2762,6 +2762,29 @@ const utilities: Array<Resource> = [
     keywords: ['orval', 'data', 'query', 'action', 'start', 'rest', 'codegen'],
     published_at: 1769436408000,
   },
+  {
+    title: '@stitchapi/solid',
+    link: 'https://github.com/rejifald/StitchAPI/tree/main/packages/solid',
+    author: 'Oleksandr Zhuravlov',
+    author_url: 'https://github.com/rejifald',
+    description:
+      'Typed, validated, streaming-first API bindings for Solid — createStitch/createStitchStream primitives that reconcile a Solid store and re-render as response deltas arrive, plus an optional TanStack-shaped queryOptions helper.',
+    type: PackageType.Package,
+    categories: [ResourceCategory.Data],
+    official: false,
+    keywords: [
+      'data',
+      'query',
+      'fetch',
+      'streaming',
+      'typed',
+      'validated',
+      'rest',
+      'http',
+      'store',
+    ],
+    published_at: 1783036800000,
+  },
 ];
 
 export default utilities;


### PR DESCRIPTION
Adds `@stitchapi/solid` to the Ecosystem **Data** category in `Utilities.data.ts`.

`@stitchapi/solid` gives Solid typed, validated, streaming-first API bindings: `createStitch` / `createStitchStream` primitives that reconcile a Solid store from a framework-agnostic reactive store and re-render as response deltas arrive, plus an optional TanStack-shaped `queryOptions` helper. Works on Solid 1.x.

- Repo: https://github.com/rejifald/StitchAPI/tree/main/packages/solid
- npm: https://www.npmjs.com/package/@stitchapi/solid

Entry appended to the end of the array following the existing format (`Data` category, `PackageType.Package`).